### PR TITLE
[FEATURE] Throw runtime error in batch sessions

### DIFF
--- a/src/Mustard/Geant4X/Interface/MPIExecutive.c++
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.c++
@@ -50,7 +50,7 @@ auto MPIExecutive::Execute(const std::string& macro) -> void {
     G4UImanager::GetUIpointer()->ExecuteMacroFile(macro.c_str());
     if (G4UImanager::GetUIpointer()->GetLastReturnCode() == fParameterUnreadable) {
         if (not fIsInteractive) {
-            Throw<std::runtime_error>("Executing macro file failed.");
+            Throw<std::runtime_error>("Failed to execute file '{}'",macro);
         }
     }
 }

--- a/src/Mustard/Geant4X/Interface/MPIExecutive.c++
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.c++
@@ -22,6 +22,8 @@
 
 #include "mplr/mplr.hpp"
 
+#include "fmt/core.h"
+
 #include <ostream>
 #include <source_location>
 #include <stdexcept>
@@ -50,7 +52,7 @@ auto MPIExecutive::Execute(const std::string& macro) -> void {
     G4UImanager::GetUIpointer()->ExecuteMacroFile(macro.c_str());
     if (G4UImanager::GetUIpointer()->GetLastReturnCode() == fParameterUnreadable) {
         if (not fIsInteractive) {
-            Throw<std::runtime_error>("Failed to execute file '{}'",macro);
+            Throw<std::runtime_error>(fmt::format("Failed to execute file '{}'", macro));
         }
     }
 }

--- a/src/Mustard/Geant4X/Interface/MPIExecutive.c++
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.c++
@@ -48,7 +48,7 @@ auto MPIExecutive::CheckSequential() const -> void {
     Throw<std::logic_error>("Interactive session must be sequential");
 }
 
-const auto MPIExecutive::Execute(const std::string& macro) -> void {
+auto MPIExecutive::Execute(const std::string& macro) const -> void {
     G4UImanager::GetUIpointer()->ExecuteMacroFile(macro.c_str());
     if (G4UImanager::GetUIpointer()->GetLastReturnCode() == fParameterUnreadable) {
         if (not fIsInteractive) {

--- a/src/Mustard/Geant4X/Interface/MPIExecutive.c++
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.c++
@@ -48,7 +48,7 @@ auto MPIExecutive::CheckSequential() const -> void {
     Throw<std::logic_error>("Interactive session must be sequential");
 }
 
-auto MPIExecutive::Execute(const std::string& macro) -> void {
+const auto MPIExecutive::Execute(const std::string& macro) -> void {
     G4UImanager::GetUIpointer()->ExecuteMacroFile(macro.c_str());
     if (G4UImanager::GetUIpointer()->GetLastReturnCode() == fParameterUnreadable) {
         if (not fIsInteractive) {

--- a/src/Mustard/Geant4X/Interface/MPIExecutive.c++
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.c++
@@ -29,7 +29,8 @@
 namespace Mustard::Geant4X::inline Interface {
 
 MPIExecutive::MPIExecutive() :
-    WeakSingleton{this} {}
+    WeakSingleton{this},
+    fIsInteractive{} {}
 
 auto MPIExecutive::CheckSequential() const -> void {
     const auto worldComm{mplr::comm_world()};
@@ -43,6 +44,15 @@ auto MPIExecutive::CheckSequential() const -> void {
                     "Interactive session must be run with only 1 process.\nThrowing an instance of std::logic_error.");
     }
     Throw<std::logic_error>("Interactive session must be sequential");
+}
+
+auto MPIExecutive::Execute(const std::string& macro) -> void {
+    G4UImanager::GetUIpointer()->ExecuteMacroFile(macro.c_str());
+    if (G4UImanager::GetUIpointer()->GetLastReturnCode() == fParameterUnreadable) {
+        if (not fIsInteractive) {
+            Throw<std::runtime_error>("Executing macro file failed.");
+        }
+    }
 }
 
 auto MPIExecutive::ExecuteCommand(const std::string& command) -> bool {

--- a/src/Mustard/Geant4X/Interface/MPIExecutive.c++
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.c++
@@ -49,8 +49,9 @@ auto MPIExecutive::CheckSequential() const -> void {
 }
 
 auto MPIExecutive::Execute(const std::string& macro) const -> void {
-    G4UImanager::GetUIpointer()->ExecuteMacroFile(macro.c_str());
-    if (G4UImanager::GetUIpointer()->GetLastReturnCode() == fParameterUnreadable) {
+    const auto uiPtr{G4UImanager::GetUIpointer()};
+    uiPtr->ExecuteMacroFile(macro.c_str());
+    if (uiPtr->GetLastReturnCode() != fCommandSucceeded) {
         if (not fIsInteractive) {
             Throw<std::runtime_error>(fmt::format("Failed to execute file '{}'", macro));
         }
@@ -66,7 +67,7 @@ auto MPIExecutive::ExecuteCommand(const std::string& command) -> bool {
         PrintLn(G4cout, "{}", command);
         return true;
     }
-    if (const auto commandStatus = G4UImanager::GetUIpointer()->ApplyCommand(command);
+    if (const auto commandStatus{G4UImanager::GetUIpointer()->ApplyCommand(command)};
         commandStatus == fCommandSucceeded) [[likely]] {
         return true;
     } else {

--- a/src/Mustard/Geant4X/Interface/MPIExecutive.h++
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.h++
@@ -23,6 +23,7 @@
 #include "Mustard/CLI/Module/ModuleBase.h++"
 #include "Mustard/Env/BasicEnv.h++"
 #include "Mustard/Env/Memory/WeakSingleton.h++"
+#include "Mustard/IO/PrettyLog.h++"
 
 #include "G4UIExecutive.hh"
 #include "G4UImanager.hh"
@@ -46,39 +47,42 @@ public:
     MPIExecutive();
 
     template<std::derived_from<CLI::ModuleBase>... Ms>
-        requires muc::is_contained_in_v<CLI::Geant4Module, Ms...>
-    auto StartSession(const CLI::CLI<Ms...>& cli, auto&& macFileOrCmdList) const -> void;
+        requires muc::tuple_contains_v<std::tuple<Ms...>, CLI::Geant4Module>
+    auto StartSession(const CLI::CLI<Ms...>& cli, auto&& macFileOrCmdList) -> void;
     template<std::derived_from<CLI::ModuleBase>... Ms, typename T>
-        requires muc::is_contained_in_v<CLI::Geant4Module, Ms...>
-    auto StartSession(const CLI::CLI<Ms...>& cli, std::initializer_list<T> cmdList = {}) const -> void;
+        requires muc::tuple_contains_v<std::tuple<Ms...>, CLI::Geant4Module>
+    auto StartSession(const CLI::CLI<Ms...>& cli, std::initializer_list<T> cmdList = {}) -> void;
 
-    auto StartSession(int argc, char* argv[], auto&& macFileOrCmdList) const -> void;
+    auto StartSession(int argc, char* argv[], auto&& macFileOrCmdList) -> void;
     template<typename T>
-    auto StartSession(int argc, char* argv[], std::initializer_list<T> cmdList = {}) const -> void;
+    auto StartSession(int argc, char* argv[], std::initializer_list<T> cmdList = {}) -> void;
 
-    auto StartInteractiveSession(int argc, char* argv[], auto&& macFileOrCmdList) const -> void;
+    auto StartInteractiveSession(int argc, char* argv[], auto&& macFileOrCmdList) -> void;
     template<typename T>
-    auto StartInteractiveSession(int argc, char* argv[], std::initializer_list<T> cmdList = {}) const -> void;
+    auto StartInteractiveSession(int argc, char* argv[], std::initializer_list<T> cmdList = {}) -> void;
 
-    auto StartBatchSession(auto&& macFileOrCmdList) const -> void;
+    auto StartBatchSession(auto&& macFileOrCmdList) -> void;
     template<typename T>
-    auto StartBatchSession(std::initializer_list<T> cmdList) const -> void;
+    auto StartBatchSession(std::initializer_list<T> cmdList) -> void;
 
 private:
     template<std::derived_from<CLI::ModuleBase>... Ms>
-        requires muc::is_contained_in_v<CLI::Geant4Module, Ms...>
-    auto StartSessionImpl(const CLI::CLI<Ms...>& cli, auto&& macFileOrCmdList) const -> void;
-    auto StartSessionImpl(int argc, char* argv[], auto&& macFileOrCmdList) const -> void;
-    auto StartInteractiveSessionImpl(int argc, char* argv[], auto&& macFileOrCmdList) const -> void;
-    auto StartBatchSessionImpl(auto&& macFileOrCmdList) const -> void;
+        requires muc::tuple_contains_v<std::tuple<Ms...>, CLI::Geant4Module>
+    auto StartSessionImpl(const CLI::CLI<Ms...>& cli, auto&& macFileOrCmdList) -> void;
+    auto StartSessionImpl(int argc, char* argv[], auto&& macFileOrCmdList) -> void;
+    auto StartInteractiveSessionImpl(int argc, char* argv[], auto&& macFileOrCmdList) -> void;
+    auto StartBatchSessionImpl(auto&& macFileOrCmdList) -> void;
 
     auto CheckSequential() const -> void;
 
+    auto Execute(const std::string& macro) -> void;
+    auto Execute(const std::ranges::input_range auto& cmdList) -> void
+        requires std::convertible_to<typename std::decay_t<decltype(cmdList)>::value_type, std::string>;
+
     static auto ExecuteCommand(const std::string& command) -> bool;
 
-    static auto Execute(const std::string& macro) -> void { G4UImanager::GetUIpointer()->ExecuteMacroFile(macro.c_str()); }
-    static auto Execute(const std::ranges::input_range auto& cmdList) -> void
-        requires std::convertible_to<typename std::decay_t<decltype(cmdList)>::value_type, std::string>;
+private:
+    bool fIsInteractive;
 };
 
 } // namespace Mustard::Geant4X::inline Interface

--- a/src/Mustard/Geant4X/Interface/MPIExecutive.h++
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.h++
@@ -75,8 +75,8 @@ private:
 
     auto CheckSequential() const -> void;
 
-    const auto Execute(const std::string& macro) -> void;
-    const auto Execute(const std::ranges::input_range auto& cmdList) -> void
+    auto Execute(const std::string& macro) const -> void;
+    auto Execute(const std::ranges::input_range auto& cmdList) const -> void
         requires std::convertible_to<typename std::decay_t<decltype(cmdList)>::value_type, std::string>;
 
     static auto ExecuteCommand(const std::string& command) -> bool;

--- a/src/Mustard/Geant4X/Interface/MPIExecutive.h++
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.h++
@@ -75,8 +75,8 @@ private:
 
     auto CheckSequential() const -> void;
 
-    auto Execute(const std::string& macro) -> void;
-    auto Execute(const std::ranges::input_range auto& cmdList) -> void
+    const auto Execute(const std::string& macro) -> void;
+    const auto Execute(const std::ranges::input_range auto& cmdList) -> void
         requires std::convertible_to<typename std::decay_t<decltype(cmdList)>::value_type, std::string>;
 
     static auto ExecuteCommand(const std::string& command) -> bool;

--- a/src/Mustard/Geant4X/Interface/MPIExecutive.inl
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.inl
@@ -108,7 +108,7 @@ auto MPIExecutive::Execute(const std::ranges::input_range auto& cmdList) -> void
             if (fIsInteractive) {
                 break;
             } else {
-                Throw<std::runtime_error>("Executing command failed.");
+                Throw<std::runtime_error>("Failed to execute command {}",command);
             }
         }
     }

--- a/src/Mustard/Geant4X/Interface/MPIExecutive.inl
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.inl
@@ -108,7 +108,7 @@ auto MPIExecutive::Execute(const std::ranges::input_range auto& cmdList) -> void
             if (fIsInteractive) {
                 break;
             } else {
-                Throw<std::runtime_error>("Failed to execute command {}",command);
+                Throw<std::runtime_error>("Last command failed");
             }
         }
     }

--- a/src/Mustard/Geant4X/Interface/MPIExecutive.inl
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.inl
@@ -19,48 +19,49 @@
 namespace Mustard::Geant4X::inline Interface {
 
 template<std::derived_from<CLI::ModuleBase>... Ms>
-    requires muc::is_contained_in_v<CLI::Geant4Module, Ms...>
-auto MPIExecutive::StartSession(const CLI::CLI<Ms...>& cli, auto&& macFileOrCmdList) const -> void {
+    requires muc::tuple_contains_v<std::tuple<Ms...>, CLI::Geant4Module>
+auto MPIExecutive::StartSession(const CLI::CLI<Ms...>& cli, auto&& macFileOrCmdList) -> void {
     StartSessionImpl(cli, std::forward<decltype(macFileOrCmdList)>(macFileOrCmdList));
 }
 
 template<std::derived_from<CLI::ModuleBase>... Ms, typename T>
-    requires muc::is_contained_in_v<CLI::Geant4Module, Ms...>
-auto MPIExecutive::StartSession(const CLI::CLI<Ms...>& cli, std::initializer_list<T> cmdList) const -> void {
+    requires muc::tuple_contains_v<std::tuple<Ms...>, CLI::Geant4Module>
+auto MPIExecutive::StartSession(const CLI::CLI<Ms...>& cli, std::initializer_list<T> cmdList) -> void {
     StartSessionImpl(cli, cmdList);
 }
 
-auto MPIExecutive::StartSession(int argc, char* argv[], auto&& macFileOrCmdList) const -> void {
+auto MPIExecutive::StartSession(int argc, char* argv[], auto&& macFileOrCmdList) -> void {
     StartSessionImpl(argc, argv, std::forward<decltype(macFileOrCmdList)>(macFileOrCmdList));
 }
 
 template<typename T>
-auto MPIExecutive::StartSession(int argc, char* argv[], std::initializer_list<T> cmdList) const -> void {
+auto MPIExecutive::StartSession(int argc, char* argv[], std::initializer_list<T> cmdList) -> void {
     StartSessionImpl(argc, argv, cmdList);
 }
 
-auto MPIExecutive::StartInteractiveSession(int argc, char* argv[], auto&& macFileOrCmdList) const -> void {
+auto MPIExecutive::StartInteractiveSession(int argc, char* argv[], auto&& macFileOrCmdList) -> void {
     StartInteractiveSessionImpl(argc, argv, std::forward<decltype(macFileOrCmdList)>(macFileOrCmdList));
 }
 
 template<typename T>
-auto MPIExecutive::StartInteractiveSession(int argc, char* argv[], std::initializer_list<T> cmdList) const -> void {
+auto MPIExecutive::StartInteractiveSession(int argc, char* argv[], std::initializer_list<T> cmdList) -> void {
     StartInteractiveSessionImpl(argc, argv, cmdList);
 }
 
-auto MPIExecutive::StartBatchSession(auto&& macFileOrCmdList) const -> void {
+auto MPIExecutive::StartBatchSession(auto&& macFileOrCmdList) -> void {
     StartBatchSessionImpl(std::forward<decltype(macFileOrCmdList)>(macFileOrCmdList));
 }
 
 template<typename T>
-auto MPIExecutive::StartBatchSession(std::initializer_list<T> cmdList) const -> void {
+auto MPIExecutive::StartBatchSession(std::initializer_list<T> cmdList) -> void {
     StartBatchSessionImpl(cmdList);
 }
 
 template<std::derived_from<CLI::ModuleBase>... Ms>
-    requires muc::is_contained_in_v<CLI::Geant4Module, Ms...>
-auto MPIExecutive::StartSessionImpl(const CLI::CLI<Ms...>& cli, auto&& macFileOrCmdList) const -> void {
+    requires muc::tuple_contains_v<std::tuple<Ms...>, CLI::Geant4Module>
+auto MPIExecutive::StartSessionImpl(const CLI::CLI<Ms...>& cli, auto&& macFileOrCmdList) -> void {
     if (cli.IsInteractive()) {
+        fIsInteractive = true;
         const auto [argc, argv]{cli.ArgcArgv()};
         auto macro{cli.Macro()};
         if (macro) {
@@ -73,15 +74,16 @@ auto MPIExecutive::StartSessionImpl(const CLI::CLI<Ms...>& cli, auto&& macFileOr
     }
 }
 
-auto MPIExecutive::StartSessionImpl(int argc, char* argv[], auto&& macFileOrCmdList) const -> void {
+auto MPIExecutive::StartSessionImpl(int argc, char* argv[], auto&& macFileOrCmdList) -> void {
     if (argc == 1) {
+        fIsInteractive = true;
         StartInteractiveSessionImpl(argc, argv, std::forward<decltype(macFileOrCmdList)>(macFileOrCmdList));
     } else {
         StartBatchSessionImpl(argv[1]);
     }
 }
 
-auto MPIExecutive::StartInteractiveSessionImpl(int argc, char* argv[], auto&& macFileOrCmdList) const -> void {
+auto MPIExecutive::StartInteractiveSessionImpl(int argc, char* argv[], auto&& macFileOrCmdList) -> void {
     CheckSequential();
 #if MUSTARD_USE_G4VIS
     G4UIExecutive uiExecutive{argc, argv};
@@ -94,17 +96,20 @@ auto MPIExecutive::StartInteractiveSessionImpl(int argc, char* argv[], auto&& ma
     uiExecutive.SessionStart();
 }
 
-auto MPIExecutive::StartBatchSessionImpl(auto&& macFileOrCmdList) const -> void {
+auto MPIExecutive::StartBatchSessionImpl(auto&& macFileOrCmdList) -> void {
     Execute(std::forward<decltype(macFileOrCmdList)>(macFileOrCmdList));
 }
 
 auto MPIExecutive::Execute(const std::ranges::input_range auto& cmdList) -> void
-    requires std::convertible_to<typename std::decay_t<decltype(cmdList)>::value_type, std::string>
-{
+    requires std::convertible_to<typename std::decay_t<decltype(cmdList)>::value_type, std::string> {
     for (auto&& command : cmdList) {
         if (const auto success{ExecuteCommand(std::forward<decltype(command)>(command))};
             not success) {
-            break;
+            if (fIsInteractive) {
+                break;
+            } else {
+                Throw<std::runtime_error>("Executing command failed.");
+            }
         }
     }
 }

--- a/src/Mustard/Geant4X/Interface/MPIExecutive.inl
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.inl
@@ -100,7 +100,7 @@ auto MPIExecutive::StartBatchSessionImpl(auto&& macFileOrCmdList) -> void {
     Execute(std::forward<decltype(macFileOrCmdList)>(macFileOrCmdList));
 }
 
-const auto MPIExecutive::Execute(const std::ranges::input_range auto& cmdList) -> void
+auto MPIExecutive::Execute(const std::ranges::input_range auto& cmdList) const -> void
     requires std::convertible_to<typename std::decay_t<decltype(cmdList)>::value_type, std::string> {
     for (auto&& command : cmdList) {
         if (const auto success{ExecuteCommand(std::forward<decltype(command)>(command))};

--- a/src/Mustard/Geant4X/Interface/MPIExecutive.inl
+++ b/src/Mustard/Geant4X/Interface/MPIExecutive.inl
@@ -100,7 +100,7 @@ auto MPIExecutive::StartBatchSessionImpl(auto&& macFileOrCmdList) -> void {
     Execute(std::forward<decltype(macFileOrCmdList)>(macFileOrCmdList));
 }
 
-auto MPIExecutive::Execute(const std::ranges::input_range auto& cmdList) -> void
+const auto MPIExecutive::Execute(const std::ranges::input_range auto& cmdList) -> void
     requires std::convertible_to<typename std::decay_t<decltype(cmdList)>::value_type, std::string> {
     for (auto&& command : cmdList) {
         if (const auto success{ExecuteCommand(std::forward<decltype(command)>(command))};


### PR DESCRIPTION
## Summary
Fix `Mustard::Geant4X::MPIExecutive` to throw `std::runtime_error` in non-interactive sessions.

Fixes: [#12](https://github.com/zhao-shihan/MACESW/issues/12) of [MACESW](https://github.com/zhao-shihan/MACESW).

## Type of change
- Bug fix

## How was this tested?
In a certain simulation program based on Mustard.  
- Build: default commands.
- Run the simulation program in a non-interactive mode, e.g.  
    ```bash
    <execuatble> [option] <macro file>/<command list>
    ```
- The program will throw a `std::runtime_error` given a wrong macro file path (or command list), rather than continue the session and exit normally.

## Checklist before requesting review
- [x]  My code follows the project coding style and linting rules.
- [x] I ran the full test-suite locally and all tests pass.
- [ ] I added/updated unit tests where applicable.
- [ ] I updated relevant documentation (README, Doxygen, or design docs).
- [x] I linked related issues and provided context in the PR description.

## Implementation details 
An `fIsInteractive` tag is added to retrieve the status of the current session (interactive or batch). When function `Execute()` failed and `fIsInteractive == false`, the program will throw `std::runtime_error`. 

## Reviewer notes
- Areas that need special attention during review: none
- Suggested reviewer: [zhao-shihan](https://github.com/zhao-shihan)

## Additional information
- The static properties of member functions `Execute(...)` in class `Mustard::Geant4X::MPIExecutive` are removed since an `fIsInteractive` tag is added as an private member.
- The const properties of the member functions `StartSession()`&`StartxxxSession()`&`StartxxxSessionImpl()` are removed for the same reason above as the previous point.
