### PR TITLE
Fix MSqM2ENNE and update Fermi constant naming

### DIFF
--- a/src/Mustard/Physics/QFT/MSqM2ENNE.c++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNE.c++
@@ -30,8 +30,8 @@ using namespace MathConstant;
 auto MSqM2ENNE::operator()(const InitialStateMomenta& pI, const FinalStateMomenta& pF) const -> double {
     // Ref: Mitrajyoti Ghosh et al., arXiv:2510.25828 [hep-ph] (Eq. 2)
     const auto& [q1, q2, q3, q4]{pF};
-    return 512 * pi * muc::pow(reduced_fermi_constant, 2) * muc::pow(fine_structure_const, 3) *
-           (pI * q2) * (q3 * q4) / muc::hypot(q4.e(), Bohr_radius * (q1.vect() * q4.vect()));
+    return 512 * pi * muc::pow(reduced_Fermi_constant, 2) * muc::pow(fine_structure_const, 3) *
+           (pI * q2) * (q3 * q4) / muc::hypot_sq(q4.e(), muonium_Bohr_radius * (q1.vect() * q4.vect()));
 }
 
 } // namespace Mustard::inline Physics::QFT

--- a/src/Mustard/Physics/QFT/MSqM2ENNEE.c++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNEE.c++
@@ -89,7 +89,7 @@ auto MSqM2ENNEE::MSqMcMule0Av(const InitialStateMomenta& pI, const FinalStateMom
     m2enneeavImpl(p2, p4);
     m2enneeavImpl(p4, p2);
 
-    return muc::pow(2 * pi * fine_structure_const * reduced_fermi_constant, 2) * pm2enneeav;
+    return muc::pow(2 * pi * fine_structure_const * reduced_Fermi_constant, 2) * pm2enneeav;
 }
 
 MUSTARD_OPTIMIZE_FAST auto MSqM2ENNEE::OneBorn(double s12, double s13, double s14, double s23, double s24, double s34,
@@ -3373,7 +3373,7 @@ MUSTARD_OPTIMIZE_FAST auto MSqM2ENNEE::MSqMcMuleLegacy(const InitialStateMomenta
                               if14 / (den1 * den4) + if23 / (den2 * den3) +
                               if24 / (den2 * den4) + if34 / (den3 * den4))};
 
-    constexpr auto constant{8. * pow(reduced_fermi_constant, 2) * pow(4. * pi * fine_structure_const, 2)};
+    constexpr auto constant{8. * pow(reduced_Fermi_constant, 2) * pow(4. * pi * fine_structure_const, 2)};
     return constant * pm2ennee;
 }
 

--- a/src/Mustard/Physics/QFT/MSqM2ENNGG.c++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNGG.c++
@@ -74,7 +74,7 @@ auto MSqM2ENNGG::operator()(const InitialStateMomenta& pI, const FinalStateMomen
     }
     pm2ennggav *= -4 / 3.;
 
-    constexpr auto constant{4 * muc::pow(reduced_fermi_constant, 2) * muc::pow(4 * pi * fine_structure_const, 2)};
+    constexpr auto constant{4 * muc::pow(reduced_Fermi_constant, 2) * muc::pow(4 * pi * fine_structure_const, 2)};
     return constant * pm2ennggav;
 }
 

--- a/src/Mustard/Utility/PhysicalConstant.h++
+++ b/src/Mustard/Utility/PhysicalConstant.h++
@@ -82,12 +82,13 @@ constexpr auto muonium_mass_c2{muon_mass_c2 + electron_mass_c2 -
                                muc::pow(fine_structure_const * muonium_reduced_mass_c2, 2) / (2 * electron_mass_c2)};
 constexpr auto muonium_decay_constant{muc::pow(fine_structure_const * muonium_reduced_mass_c2, 3) * muonium_mass_c2 /
                                       (2 * CLHEP::pi * muon_mass_c2 * electron_mass_c2)};
+constexpr auto muonium_Bohr_radius{hbarc / (fine_structure_const * muonium_reduced_mass_c2)};
 
 constexpr auto muon_lifetime{2.1969811 * CLHEP::us};
 constexpr auto muonium_lifetime{muon_lifetime};
 
-constexpr auto reduced_fermi_constant{1.1663788e-5 * muc::pow(CLHEP::GeV, -2)};
-constexpr auto fermi_constant{reduced_fermi_constant * muc::pow(hbarc, 3)};
+constexpr auto reduced_Fermi_constant{1.1663788e-5 * muc::pow(CLHEP::GeV, -2)};
+constexpr auto Fermi_constant{reduced_Fermi_constant * muc::pow(hbarc, 3)};
 // --            Extra constants              -- //
 
 } // namespace Mustard::inline Utility::PhysicalConstant


### PR DESCRIPTION
## Summary
This pull request
- fixes `MSqM2ENNE`.
- updates several physics calculations to use consistent naming for physical constants and introduces a new constant for the muonium Bohr radius. The main focus is on replacing the old `reduced_fermi_constant` and `fermi_constant` names with the new `reduced_Fermi_constant` and `Fermi_constant`, and on using the new `muonium_Bohr_radius` where appropriate.

**Physical constant naming consistency:**

* Updated all usages of `reduced_fermi_constant` to `reduced_Fermi_constant` and `fermi_constant` to `Fermi_constant` in both the calculation functions and the physical constants header for improved clarity and consistency. [[1]](diffhunk://#diff-725067b7de495ce88de0771a8c0b4821c04a8c783144c690b1b15b202f39db1cR85-R91) [[2]](diffhunk://#diff-0caf86b459d192871169069eb7d233272fdadec494f8546f42bcb1241d035c6fL33-R34) [[3]](diffhunk://#diff-231ae610099e95796d139ce804818dc0d33abad56a3b355c98090fbb003c53ccL92-R92) [[4]](diffhunk://#diff-231ae610099e95796d139ce804818dc0d33abad56a3b355c98090fbb003c53ccL3376-R3376) [[5]](diffhunk://#diff-59838d1c31fdc479baea7f56e856fc69b03d1b477e1fc1f59aa42ccf77d10306L77-R77)

**Introduction of new constants:**

* Added a new constant `muonium_Bohr_radius` to `PhysicalConstant.h++` and updated calculations in `MSqM2ENNE.c++` to use this value instead of the previous `Bohr_radius`. [[1]](diffhunk://#diff-725067b7de495ce88de0771a8c0b4821c04a8c783144c690b1b15b202f39db1cR85-R91) [[2]](diffhunk://#diff-0caf86b459d192871169069eb7d233272fdadec494f8546f42bcb1241d035c6fL33-R34)

**Formula improvements:**

* Fix matrix element in `MSqM2ENNE::operator()`.

## Type of change
- Bug fix (non-breaking change which fixes an issue)
