### PR TITLE
Fix MasterPrint functions

### DIFF
--- a/src/Mustard/IO/Print.inl
+++ b/src/Mustard/IO/Print.inl
@@ -126,7 +126,7 @@ template<char L, typename... Ts>
 auto MasterPrint(fmt::format_string<Ts...> fmt, Ts&&... args) -> void {
     if (not mplr::available() or
         mplr::comm_world().rank() == 0) {
-        Print(std::move(fmt), std::forward<Ts>(args)...);
+        Print<L>(std::move(fmt), std::forward<Ts>(args)...);
     }
 }
 
@@ -134,7 +134,7 @@ template<char L, typename... Ts>
 auto MasterPrintLn(fmt::format_string<Ts...> fmt, Ts&&... args) -> void {
     if (not mplr::available() or
         mplr::comm_world().rank() == 0) {
-        PrintLn(std::move(fmt), std::forward<Ts>(args)...);
+        PrintLn<L>(std::move(fmt), std::forward<Ts>(args)...);
     }
 }
 
@@ -142,7 +142,7 @@ template<char L, typename... Ts>
 auto MasterPrint(fmt::text_style ts, fmt::format_string<Ts...> fmt, Ts&&... args) -> void {
     if (not mplr::available() or
         mplr::comm_world().rank() == 0) {
-        Print(ts, std::move(fmt), std::forward<Ts>(args)...);
+        Print<L>(ts, std::move(fmt), std::forward<Ts>(args)...);
     }
 }
 
@@ -150,7 +150,7 @@ template<char L, typename... Ts>
 auto MasterPrint(std::FILE* f, fmt::format_string<Ts...> fmt, Ts&&... args) -> void {
     if (not mplr::available() or
         mplr::comm_world().rank() == 0) {
-        Print(f, std::move(fmt), std::forward<Ts>(args)...);
+        Print<L>(f, std::move(fmt), std::forward<Ts>(args)...);
     }
 }
 
@@ -158,7 +158,7 @@ template<char L, typename... Ts>
 auto MasterPrintLn(std::FILE* f, fmt::format_string<Ts...> fmt, Ts&&... args) -> void {
     if (not mplr::available() or
         mplr::comm_world().rank() == 0) {
-        PrintLn(f, std::move(fmt), std::forward<Ts>(args)...);
+        PrintLn<L>(f, std::move(fmt), std::forward<Ts>(args)...);
     }
 }
 
@@ -166,7 +166,7 @@ template<char L, typename... Ts>
 auto MasterPrint(std::FILE* f, fmt::text_style ts, fmt::format_string<Ts...> fmt, Ts&&... args) -> void {
     if (not mplr::available() or
         mplr::comm_world().rank() == 0) {
-        Print(f, ts, std::move(fmt), std::forward<Ts>(args)...);
+        Print<L>(f, ts, std::move(fmt), std::forward<Ts>(args)...);
     }
 }
 
@@ -174,7 +174,7 @@ template<char L, typename... Ts>
 auto MasterPrint(std::ostream& os, fmt::format_string<Ts...> fmt, Ts&&... args) -> void {
     if (not mplr::available() or
         mplr::comm_world().rank() == 0) {
-        Print(os, std::move(fmt), std::forward<Ts>(args)...);
+        Print<L>(os, std::move(fmt), std::forward<Ts>(args)...);
     }
 }
 
@@ -182,7 +182,7 @@ template<char L, typename... Ts>
 auto MasterPrintLn(std::ostream& os, fmt::format_string<Ts...> fmt, Ts&&... args) -> void {
     if (not mplr::available() or
         mplr::comm_world().rank() == 0) {
-        PrintLn(os, std::move(fmt), std::forward<Ts>(args)...);
+        PrintLn<L>(os, std::move(fmt), std::forward<Ts>(args)...);
     }
 }
 
@@ -190,7 +190,7 @@ template<char L, typename... Ts>
 auto MasterPrint(std::ostream& os, fmt::text_style ts, fmt::format_string<Ts...> fmt, Ts&&... args) -> void {
     if (not mplr::available() or
         mplr::comm_world().rank() == 0) {
-        Print(os, ts, std::move(fmt), std::forward<Ts>(args)...);
+        Print<L>(os, ts, std::move(fmt), std::forward<Ts>(args)...);
     }
 }
 
@@ -198,7 +198,7 @@ template<char L, typename... Ts>
 auto MasterPrint(std::wostream& os, fmt::wformat_string<Ts...> fmt, Ts&&... args) -> void {
     if (not mplr::available() or
         mplr::comm_world().rank() == 0) {
-        Print(os, std::move(fmt), std::forward<Ts>(args)...);
+        Print<L>(os, std::move(fmt), std::forward<Ts>(args)...);
     }
 }
 
@@ -206,7 +206,7 @@ template<char L, typename... Ts>
 auto MasterPrintLn(std::wostream& os, fmt::wformat_string<Ts...> fmt, Ts&&... args) -> void {
     if (not mplr::available() or
         mplr::comm_world().rank() == 0) {
-        PrintLn(os, std::move(fmt), std::forward<Ts>(args)...);
+        PrintLn<L>(os, std::move(fmt), std::forward<Ts>(args)...);
     }
 }
 
@@ -214,7 +214,7 @@ template<char L, typename... Ts>
 auto MasterPrint(std::wostream& os, fmt::text_style ts, fmt::wformat_string<Ts...> fmt, Ts&&... args) -> void {
     if (not mplr::available() or
         mplr::comm_world().rank() == 0) {
-        Print(os, ts, std::move(fmt), std::forward<Ts>(args)...);
+        Print<L>(os, ts, std::move(fmt), std::forward<Ts>(args)...);
     }
 }
 
@@ -222,7 +222,7 @@ template<char L>
 auto MasterVPrint(auto&&... args) -> void {
     if (not mplr::available() or
         mplr::comm_world().rank() == 0) {
-        VPrint(std::forward<decltype(args)>(args)...);
+        VPrint<L>(std::forward<decltype(args)>(args)...);
     }
 }
 


### PR DESCRIPTION
## Summary
This pull request updates the `MasterPrint` and related functions in `src/Mustard/IO/Print.inl` to consistently forward the template parameter `L` to the underlying `Print` and `PrintLn` functions.

## Type of change
- Bug fix (non-breaking change which fixes an issue)
