### PR TITLE
Update .clang-format to add new options

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -61,9 +61,9 @@ PackConstructorInitializers: Never
 PointerAlignment: Left
 ReferenceAlignment: Left
 ReflowComments: true
-# RequiresClausePosition: OwnLineWithBrace
-# RemoveEmptyLinesInUnwrappedLines: true
-# RequiresExpressionIndentation: OuterScope
+RequiresClausePosition: OwnLineWithBrace
+RemoveEmptyLinesInUnwrappedLines: true
+RequiresExpressionIndentation: OuterScope
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 0
 SortIncludes: CaseSensitive


### PR DESCRIPTION
## Summary
This pull request updates the `.clang-format` configuration file to enable several code formatting options that were previously commented out. These changes will affect how C++ code is automatically formatted, particularly regarding the placement of requires clauses, removal of empty lines, and indentation of requires expressions.

Formatting configuration changes:

* Enabled `RequiresClausePosition` to place requires clauses on their own line with the brace, improving readability of constrained functions.
* Enabled `RemoveEmptyLinesInUnwrappedLines` to automatically remove unnecessary empty lines in unwrapped code blocks, helping maintain cleaner code.
* Enabled `RequiresExpressionIndentation` to use outer scope indentation for requires expressions, ensuring consistent indentation style.

## Type of change
- CI / tooling

## Checklist before requesting review
- [x] I have read the [contributing guidelines](https://github.com/zhao-shihan/Mustard/blob/main/CONTRIBUTING.md)
- [x] The PR targets the `main` branch.
- [x] I linked related issues and provided context in the PR description.
- [x] My code follows the [coding style guide](https://github.com/zhao-shihan/Mustard/blob/main/STYLE_GUIDE.md) and linting rules.
- [x] I added/updated unit tests where applicable.
- [x] I updated relevant documentation (README, Doxygen, or design docs).
- [x] I ran the test-suite locally and all tests pass.
- [x] All CI checks pass.
