### PR TITLE
Don't mark Mustard::Throw noinline

### DIFF
--- a/src/Mustard/IO/PrettyLog.h++
+++ b/src/Mustard/IO/PrettyLog.h++
@@ -18,8 +18,6 @@
 
 #pragma once
 
-#include "Mustard/Utility/FunctionAttribute.h++"
-
 #include "mplr/mplr.hpp"
 
 #include <concepts>

--- a/src/Mustard/IO/PrettyLog.h++
+++ b/src/Mustard/IO/PrettyLog.h++
@@ -64,7 +64,7 @@ auto MasterPrintError(std::string_view message, const std::source_location& loca
 /// @param message The exception message.
 /// @param location Source location. Default is current.
 template<std::constructible_from<std::string> AException>
-[[noreturn]] MUSTARD_NOINLINE auto Throw(std::string_view message, const std::source_location& location = std::source_location::current()) -> void;
+[[noreturn]] auto Throw(std::string_view message, const std::source_location& location = std::source_location::current()) -> void;
 
 namespace internal {
 auto PrettyException(std::string_view message, const std::source_location& location) -> std::string;

--- a/src/Mustard/IO/PrettyLog.inl
+++ b/src/Mustard/IO/PrettyLog.inl
@@ -1,7 +1,7 @@
 namespace Mustard::inline IO {
 
 template<std::constructible_from<std::string> AException>
-[[noreturn]] MUSTARD_NOINLINE auto Throw(std::string_view message, const std::source_location& location) -> void {
+[[noreturn]] auto Throw(std::string_view message, const std::source_location& location) -> void {
     throw AException(internal::PrettyException(message, location));
 }
 


### PR DESCRIPTION
## Summary
This pull request makes a minor change to the `Throw` function template in both the header and implementation files since it's [[noreturn]]. Specifically, it removes the `MUSTARD_NOINLINE` attribute from the function declaration and definition. This may affect compiler inlining behavior but does not change the function's logic or usage.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting review
- [x] I have read the [contributing guidelines](https://github.com/zhao-shihan/Mustard/blob/main/CONTRIBUTING.md)
- [x] The PR targets the `main` branch.
- [x] I linked related issues and provided context in the PR description.
- [x] My code follows the [coding style guide](https://github.com/zhao-shihan/Mustard/blob/main/STYLE_GUIDE.md) and linting rules.
- [x] I added/updated unit tests where applicable.
- [x] I updated relevant documentation (README, Doxygen, or design docs).
- [x] I ran the test-suite locally and all tests pass.
- [x] All CI checks pass.
