### PR TITLE
Update yaml-cpp version to 0.9.0 and update README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ set(MUSTARD_BUILTIN_INDICATORS_VERSION 2.3 CACHE STRING "Set built-in indicators
 set(MUSTARD_BUILTIN_MPLR_VERSION 0.25.1003 CACHE STRING "Set built-in MPLR version (if required).")
 set(MUSTARD_BUILTIN_MSGSL_VERSION 4.2.0 CACHE STRING "Set built-in Microsoft.GSL version (if required).")
 set(MUSTARD_BUILTIN_MUC_VERSION 0.25.1217 CACHE STRING "Set built-in muc version (if required).")
-set(MUSTARD_BUILTIN_YAML_CPP_VERSION 0.8.2 CACHE STRING "Set built-in yaml-cpp version (if required).")
+set(MUSTARD_BUILTIN_YAML_CPP_VERSION 0.9.0 CACHE STRING "Set built-in yaml-cpp version (if required).")
 set(MUSTARD_DEBUG_POSTFIX d CACHE STRING "Debug library postfix.")
 
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Mustard
 
 [![GitHub License](https://img.shields.io/github/license/zhao-shihan/Mustard?color=red)](COPYING)
+![GitHub Created At](https://img.shields.io/github/created-at/zhao-shihan/Mustard?color=green)
 ![GitHub top language](https://img.shields.io/github/languages/top/zhao-shihan/Mustard?color=f34b7d)
-[![GitHub activity](https://img.shields.io/github/commit-activity/m/zhao-shihan/Mustard)](https://github.com/zhao-shihan/Mustard/pulse)
 ![GitHub last commit](https://img.shields.io/github/last-commit/zhao-shihan/Mustard)
-[![GitHub release](https://badgen.net/github/release/zhao-shihan/Mustard)](https://github.com/zhao-shihan/Mustard/releases)
 [![GitHub contributors](https://img.shields.io/github/contributors/zhao-shihan/Mustard?style=flat)](https://github.com/zhao-shihan/Mustard/graphs/contributors)
+![GitHub repo size](https://img.shields.io/github/repo-size/zhao-shihan/Mustard)
 
 **Mustard** is a modern, high-performance offline software framework designed for particle physics experiments. It provides a generic architecture with core features including:
 - **Distributed computing:** Scalable parallel processing capabilities.
@@ -63,7 +63,7 @@ The following dependencies are optional. If they are not found on your system du
 | [**Microsoft.GSL**](https://github.com/Microsoft/GSL)                       | 4.2.0       | ISO C++ guidelines support library                       |
 | [**MPLR**](https://github.com/zhao-shihan/mplr)                             | 0.25.1003   | A C++17 message passing library based on MPI             |
 | [**muc**](https://github.com/zhao-shihan/muc)                               | 0.25.1217   | A standard non-standard C++ library                      |
-| [**zhao-shihan/yaml-cpp**](https://github.com/zhao-shihan/yaml-cpp)         | 0.8.2       | A YAML parser and emitter in C++                         |
+| [**yaml-cpp**](https://github.com/jbeder/yaml-cpp)                          | 0.9.0       | A YAML parser and emitter in C++                         |
 
 ## Projects using this library
 
@@ -71,6 +71,8 @@ Mustard has been used as the framework for the following projects:
 
 - [**MACESW**](https://github.com/zhao-shihan/MACESW): Muonium-to-Antimuonium Conversion Experiment (MACE) offline software
 - [**MusAirS**](https://github.com/zhao-shihan/MusAirS): An air shower simulation tool
+- [**Musae**](https://doi.org/10.1063/5.0273373): **Mu**Grid **s**imul**a**tion infrastructur**e**, or **Mu**on **s**cattering and **a**bsorption tomography simulation softwar**e**
+- [**CRmuSRSW**](https://arxiv.org/abs/2505.13877): CRmuSR (Cosmic-ray muSR) offline software
 
 They are also examples demonstrating the usage of Mustard.
 
@@ -80,7 +82,7 @@ If you are aware of other projects using this library, please let me know by ema
 
 If you use Mustard in your research, please cite the following papers:
 
-**BAI Ai-Yu, CAI Hanjie, CHEN Chang-Lin, et al (MACE working group).**  
-**Conceptual Design of the Muonium-to-Antimuonium Conversion Experiment (MACE) [DB/OL].**  
-*arXiv preprint*, 2024: 2410.18817 [hep-ex].  
-https://arxiv.org/abs/2410.18817.
+**BAI Ai-Yu, CAI Hanjie, CHEN Chang-Lin, et al. (MACE working group).**  
+**Conceptual Design of the Muonium-to-Antimuonium Conversion Experiment (MACE)** [J].  
+*Nucl. Sci. Tech.*, 2026, 37: 57. DOI: 10.1007/s41365-025-01876-0. arXiv: 2410.18817 [hep-ex].  
+https://doi.org/10.1007/s41365-025-01876-0.

--- a/cmake/LookForYamlCpp.cmake
+++ b/cmake/LookForYamlCpp.cmake
@@ -16,7 +16,7 @@
 
 message(STATUS "Looking for yaml-cpp")
 
-set(MUSTARD_YAML_CPP_MINIMUM_REQUIRED 0.8.2)
+set(MUSTARD_YAML_CPP_MINIMUM_REQUIRED 0.9.0)
 
 if(NOT MUSTARD_BUILTIN_YAML_CPP)
     find_package(yaml-cpp ${MUSTARD_YAML_CPP_MINIMUM_REQUIRED})
@@ -35,7 +35,7 @@ if(MUSTARD_BUILTIN_YAML_CPP)
     endif()
     # set download dest and URL
     set(MUSTARD_BUILTIN_YAML_CPP_SRC_DIR "${MUSTARD_PROJECT_3RDPARTY_DIR}/yaml-cpp-${MUSTARD_BUILTIN_YAML_CPP_VERSION}")
-    set(MUSTARD_BUILTIN_YAML_CPP_URL "https://github.com/zhao-shihan/yaml-cpp/archive/refs/tags/${MUSTARD_BUILTIN_YAML_CPP_VERSION}.tar.gz")
+    set(MUSTARD_BUILTIN_YAML_CPP_URL "https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-${MUSTARD_BUILTIN_YAML_CPP_VERSION}.tar.gz")
     # reuse or download
     include(FetchContent)
     if(EXISTS "${MUSTARD_BUILTIN_YAML_CPP_SRC_DIR}/CMakeLists.txt")


### PR DESCRIPTION
## Summary
This pull request updates the documentation and build configuration to use the official `yaml-cpp` library at version 0.9.0, replacing the previous fork and version. It also enhances the `README.md` with new project references and updates citation information.

**Dependency updates:**
* Updated the required and built-in version of `yaml-cpp` to 0.9.0 in `CMakeLists.txt` and `cmake/LookForYamlCpp.cmake`. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL90-R90) [[2]](diffhunk://#diff-2d681a80da19dec314a517d99460043ec0ce073b5a776f834dd9a8282a9f106aL19-R19)
* Changed the source and download URL for `yaml-cpp` to point to the official repository (`jbeder/yaml-cpp`) instead of the previous fork.

**Documentation improvements:**
* Updated the dependency table in `README.md` to reference the official `yaml-cpp` repository and version 0.9.0.
* Added new badges for repository creation date and size, and removed less relevant badges.
* Listed new projects using Mustard, including Musae and CRmuSRSW, with appropriate references.

**Citation updates:**
* Updated the MACE experiment citation to reference the published journal article and DOI instead of the preprint.

## Type of change
- New feature (non-breaking change which adds functionality)
