### PR TITLE
Refactor Data::Tuple

### DIFF
--- a/src/Mustard/Data/Tuple.h++
+++ b/src/Mustard/Data/Tuple.h++
@@ -243,10 +243,12 @@ private:
     template<gsl::index L, gsl::index R>
     MUSTARD_ALWAYS_INLINE auto VisitImpl(gsl::index i, auto&& F) const&& -> void;
 
-    static auto DynIndex(std::string_view name) -> gsl::index;
+    MUSTARD_ALWAYS_INLINE static auto DynIndex(std::string_view name) -> gsl::index;
 
 private:
     typename Model::StdTuple fTuple;
+
+    static const muc::flat_hash_map<std::string_view, gsl::index> fgDynIndexMap;
 };
 
 template<typename... Ts>

--- a/src/Mustard/Data/Tuple.h++
+++ b/src/Mustard/Data/Tuple.h++
@@ -108,48 +108,9 @@ struct tuple_element<I, T>
 
 namespace Mustard::Data {
 
-namespace internal {
-
-/// @brief Helper class for `Tuple` friend `Get` function.
-template<typename ADerived>
-class EnableGet {
-    template<muc::ceta_string... ANames>
-        requires(sizeof...(ANames) >= 1)
-    friend constexpr auto Get(const ADerived& t) -> decltype(auto) { return t.template Get<ANames...>(); }
-    template<muc::ceta_string... ANames>
-        requires(sizeof...(ANames) >= 1)
-    friend constexpr auto Get(ADerived& t) -> decltype(auto) { return t.template Get<ANames...>(); }
-    template<muc::ceta_string... ANames>
-        requires(sizeof...(ANames) >= 1)
-    friend constexpr auto Get(ADerived&& t) -> decltype(auto) { return std::move(t).template Get<ANames...>(); }
-    template<muc::ceta_string... ANames>
-        requires(sizeof...(ANames) >= 1)
-    friend constexpr auto Get(const ADerived&& t) -> decltype(auto) { return std::move(t).template Get<ANames...>(); }
-
-    template<muc::ceta_string AName, typename T>
-    friend constexpr auto GetAs(const ADerived& t) -> decltype(auto) { return t.template Get<AName>().template As<T>(); }
-    template<muc::ceta_string AName, typename T>
-    friend constexpr auto GetAs(ADerived&& t) -> decltype(auto) { return std::move(t).template Get<AName>().template As<T>(); }
-
-    template<gsl::index I>
-    friend constexpr auto get(const ADerived& t) -> decltype(auto) { return t.template Get<std::tuple_element_t<I, ADerived>::Name()>(); }
-    template<gsl::index I>
-    friend constexpr auto get(ADerived& t) -> decltype(auto) { return t.template Get<std::tuple_element_t<I, ADerived>::Name()>(); }
-    template<gsl::index I>
-    friend constexpr auto get(ADerived&& t) -> decltype(auto) { return std::move(t).template Get<std::tuple_element_t<I, ADerived>::Name()>(); }
-    template<gsl::index I>
-    friend constexpr auto get(const ADerived&& t) -> decltype(auto) { return std::move(t).template Get<std::tuple_element_t<I, ADerived>::Name()>(); }
-
-protected:
-    constexpr EnableGet();
-    constexpr ~EnableGet() = default;
-};
-
-} // namespace internal
-
 /// @brief Data model defined tuple.
 template<TupleModelizable... Ts>
-class Tuple : public internal::EnableGet<Tuple<Ts...>> {
+class Tuple {
 public:
     using Model = TupleModel<Ts...>;
 
@@ -206,6 +167,41 @@ public:
 
     static constexpr auto Size() -> auto { return Model::Size(); }
     static constexpr auto NameVector() -> auto { return Model::NameVector(); }
+
+    template<muc::ceta_string... ANames>
+        requires(sizeof...(ANames) >= 1)
+    friend constexpr auto Get(const Tuple<Ts...>& t) -> decltype(auto) { return t.template Get<ANames...>(); }
+    template<muc::ceta_string... ANames>
+        requires(sizeof...(ANames) >= 1)
+    friend constexpr auto Get(Tuple<Ts...>& t) -> decltype(auto) { return t.template Get<ANames...>(); }
+    template<muc::ceta_string... ANames>
+        requires(sizeof...(ANames) >= 1)
+    friend constexpr auto Get(Tuple<Ts...>&& t) -> decltype(auto) { return std::move(t).template Get<ANames...>(); }
+    template<muc::ceta_string... ANames>
+        requires(sizeof...(ANames) >= 1)
+    friend constexpr auto Get(const Tuple<Ts...>&& t) -> decltype(auto) { return std::move(t).template Get<ANames...>(); }
+
+    template<muc::ceta_string AName, typename T>
+    friend constexpr auto Get(const Tuple<Ts...>& t) -> decltype(auto) { return t.template Get<AName>().template As<T>(); }
+    template<muc::ceta_string AName, typename T>
+    friend constexpr auto Get(Tuple<Ts...>&& t) -> decltype(auto) { return std::move(t).template Get<AName>().template As<T>(); }
+
+    template<gsl::index I>
+    friend constexpr auto get(const Tuple<Ts...>& t) -> decltype(auto) { return t.template Get<std::tuple_element_t<I, Tuple<Ts...>>::Name()>(); }
+    template<gsl::index I>
+    friend constexpr auto get(Tuple<Ts...>& t) -> decltype(auto) { return t.template Get<std::tuple_element_t<I, Tuple<Ts...>>::Name()>(); }
+    template<gsl::index I>
+    friend constexpr auto get(Tuple<Ts...>&& t) -> decltype(auto) { return std::move(t).template Get<std::tuple_element_t<I, Tuple<Ts...>>::Name()>(); }
+    template<gsl::index I>
+    friend constexpr auto get(const Tuple<Ts...>&& t) -> decltype(auto) { return std::move(t).template Get<std::tuple_element_t<I, Tuple<Ts...>>::Name()>(); }
+
+    template<SubTuple<Tuple<Ts...>> ATuple>
+    friend constexpr auto As(const Tuple<Ts...>& t) -> decltype(auto) { return t.template As<ATuple>(); }
+
+    friend auto Visit(const Tuple<Ts...>& t, std::string_view name, auto&& F) -> void { t.template Visit(name, std::forward<decltype(F)>(F)); }
+    friend auto Visit(Tuple<Ts...>& t, std::string_view name, auto&& F) -> void { t.template Visit(name, std::forward<decltype(F)>(F)); }
+    friend auto Visit(Tuple<Ts...>&& t, std::string_view name, auto&& F) -> void { std::move(t).template Visit(name, std::forward<decltype(F)>(F)); }
+    friend auto Visit(const Tuple<Ts...>&& t, std::string_view name, auto&& F) -> void { std::move(t).template Visit(name, std::forward<decltype(F)>(F)); }
 
 private:
     template<gsl::index I>

--- a/src/Mustard/Data/Tuple.inl
+++ b/src/Mustard/Data/Tuple.inl
@@ -29,6 +29,16 @@ constexpr EnableGet<ADerived>::EnableGet() {
 } // namespace internal
 
 template<TupleModelizable... Ts>
+const muc::flat_hash_map<std::string_view, gsl::index> Tuple<Ts...>::fgDynIndexMap{
+    []<gsl::index... Is>(gslx::index_sequence<Is...>) {
+        muc::flat_hash_map<std::string_view, gsl::index> indexMap;
+        indexMap.reserve(sizeof...(Is));
+        (..., indexMap.emplace(std::tuple_element_t<Is, typename Model::StdTuple>::Name().sv(), Is));
+        indexMap.shrink_to_fit();
+        return indexMap;
+    }(gslx::make_index_sequence<Size()>{})};
+
+template<TupleModelizable... Ts>
 template<TupleLike ATuple>
 constexpr auto Tuple<Ts...>::operator==(const ATuple& that) const -> auto {
     if constexpr (not EquivalentTuple<Tuple, ATuple>) {
@@ -134,16 +144,9 @@ MUSTARD_ALWAYS_INLINE auto Tuple<Ts...>::VisitImpl(gsl::index i, auto&& F) const
 #undef MUSTARD_DATA_TUPLE_VISIT_IMPL
 
 template<TupleModelizable... Ts>
-auto Tuple<Ts...>::DynIndex(std::string_view name) -> gsl::index {
-    static const auto index{
-        []<gsl::index... Is>(gslx::index_sequence<Is...>) {
-            muc::flat_hash_map<std::string_view, gsl::index> indexMap;
-            indexMap.reserve(sizeof...(Is));
-            (..., indexMap.emplace(std::tuple_element_t<Is, typename Model::StdTuple>::Name().sv(), Is));
-            return indexMap;
-        }(gslx::make_index_sequence<Size()>{})};
+MUSTARD_ALWAYS_INLINE auto Tuple<Ts...>::DynIndex(std::string_view name) -> gsl::index {
     try {
-        return index.at(name);
+        return fgDynIndexMap.at(name);
     } catch (const std::out_of_range& e) {
         PrintError(fmt::format("No field named '{}'", name));
         throw e;

--- a/src/Mustard/Data/Tuple.inl
+++ b/src/Mustard/Data/Tuple.inl
@@ -18,23 +18,12 @@
 
 namespace Mustard::Data {
 
-namespace internal {
-
-template<typename ADerived>
-constexpr EnableGet<ADerived>::EnableGet() {
-    static_assert(std::derived_from<ADerived, EnableGet>);
-    static_assert(TupleLike<ADerived>);
-}
-
-} // namespace internal
-
 template<TupleModelizable... Ts>
 const muc::flat_hash_map<std::string_view, gsl::index> Tuple<Ts...>::fgDynIndexMap{
     []<gsl::index... Is>(gslx::index_sequence<Is...>) {
         muc::flat_hash_map<std::string_view, gsl::index> indexMap;
         indexMap.reserve(sizeof...(Is));
         (..., indexMap.emplace(std::tuple_element_t<Is, typename Model::StdTuple>::Name().sv(), Is));
-        indexMap.shrink_to_fit();
         return indexMap;
     }(gslx::make_index_sequence<Size()>{})};
 
@@ -112,9 +101,8 @@ constexpr auto Tuple<Ts...>::AsImpl() const -> ATuple {
                 Throw<std::invalid_argument>(fmt::format("The function provided is not invocable with {}", \
                                                          muc::try_demangle(typeid(*GetImpl).name())));     \
             }                                                                                              \
-        } else {                                                                                           \
-            return VisitImpl<L + 1, R>(i, std::forward<decltype(F)>(F));                                   \
         }                                                                                                  \
+        return VisitImpl<L + 1, R>(i, std::forward<decltype(F)>(F));                                       \
     }
 
 template<TupleModelizable... Ts>


### PR DESCRIPTION
## Summary
This pull request refactors the implementation of the `Tuple` class in the Mustard data library to simplify its design and improve runtime efficiency. The most significant change is the removal of the `EnableGet` helper class, with its friend functions now defined directly within `Tuple`. Additionally, the code now uses a static hash map for dynamic field indexing, which reduces redundant computation and improves performance.

### Refactoring and simplification

* Removed the `internal::EnableGet` helper class, moving all friend function definitions (such as `Get`, `GetAs`, and `get`) directly into the `Tuple` class. This streamlines the code and makes friend function declarations more explicit and maintainable. [[1]](diffhunk://#diff-0fd7d0963e68fdc8f25ac3a25495f2ff6345fa8db58669b52bc2783f813b6025L111-R113) [[2]](diffhunk://#diff-0fd7d0963e68fdc8f25ac3a25495f2ff6345fa8db58669b52bc2783f813b6025R171-R205)
* Rename `GetAs` as `Get`.

### Performance improvements

* Replaced the previous per-call construction of the dynamic index map in `DynIndex` with a static member (`fgDynIndexMap`) initialized at compile time. This change ensures that field lookup by name is efficient and avoids repeated map construction. [[1]](diffhunk://#diff-fef061f0498ab31a0e99f595d8a01073e397a677876a2fa9cb19ff4e96f3e1a9L21-R28) [[2]](diffhunk://#diff-fef061f0498ab31a0e99f595d8a01073e397a677876a2fa9cb19ff4e96f3e1a9L137-R137)
* Marked the `DynIndex` method as `MUSTARD_ALWAYS_INLINE` to encourage the compiler to inline this function for better performance. [[1]](diffhunk://#diff-0fd7d0963e68fdc8f25ac3a25495f2ff6345fa8db58669b52bc2783f813b6025L246-R247) [[2]](diffhunk://#diff-fef061f0498ab31a0e99f595d8a01073e397a677876a2fa9cb19ff4e96f3e1a9L137-R137)

### Minor logic adjustment

* Simplified the control flow in the `VisitImpl` method, removing redundant branches and ensuring the recursive call is always executed after the main logic.

## Type of change
- Refactor
