### PR TITLE
Inlining namespace Math

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@ Fixes: #<issue-number> (if applicable)
 (Select one or more and delete other options from below)
 - Bug fix (non-breaking change which fixes an issue)
 - New feature (non-breaking change which adds functionality)
+- Refactor (non-breaking change which optimizes code structure)
 - Breaking change (fix or feature that would cause existing behavior to change)
 - Documentation update
 - CI / tooling

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mustard
 
 [![GitHub License](https://img.shields.io/github/license/zhao-shihan/Mustard?color=red)](COPYING)
-![GitHub Created At](https://img.shields.io/github/created-at/zhao-shihan/Mustard?color=green)
+![GitHub Created At](https://img.shields.io/github/created-at/zhao-shihan/Mustard?color=blue)
 ![GitHub top language](https://img.shields.io/github/languages/top/zhao-shihan/Mustard?color=f34b7d)
 ![GitHub last commit](https://img.shields.io/github/last-commit/zhao-shihan/Mustard)
 [![GitHub contributors](https://img.shields.io/github/contributors/zhao-shihan/Mustard?style=flat)](https://github.com/zhao-shihan/Mustard/graphs/contributors)

--- a/src/Mustard/CLHEPX/Random/MersenneTwister.h++
+++ b/src/Mustard/CLHEPX/Random/MersenneTwister.h++
@@ -24,7 +24,7 @@
 
 namespace Mustard::CLHEPX::Random {
 
-using MT1993732 = CLHEPX::Random::Wrap<Math::Random::MT1993732>;
-using MT1993764 = CLHEPX::Random::Wrap<Math::Random::MT1993764>;
+using MT1993732 = CLHEPX::Random::Wrap<Random::MT1993732>;
+using MT1993764 = CLHEPX::Random::Wrap<Random::MT1993764>;
 
 } // namespace Mustard::CLHEPX::Random

--- a/src/Mustard/CLHEPX/Random/Wrap.h++
+++ b/src/Mustard/CLHEPX/Random/Wrap.h++
@@ -46,7 +46,7 @@ namespace Mustard::CLHEPX::Random {
 /// UniformPseudoRandomBitGenerator.
 ///
 /// @tparam PRBG Mustard UniformPseudoRandomBitGenerator type to wrap
-///   - Must satisfy Mustard::Math::Random::UniformPseudoRandomBitGenerator
+///   - Must satisfy Mustard::Random::UniformPseudoRandomBitGenerator
 ///
 /// @note Implements all CLHEP engine virtual methods except getState()
 /// @warning getState() is intentionally non-functional

--- a/src/Mustard/Detector/Field/ElectromagneticField.h++
+++ b/src/Mustard/Detector/Field/ElectromagneticField.h++
@@ -31,12 +31,12 @@ concept ElectromagneticField =
     requires(const F f, muc::array3d x) {
         { f.B(x) } -> std::same_as<muc::array3d>;
         { f.E(x) } -> std::same_as<muc::array3d>;
-        { f.BE(x).B } -> std::same_as<muc::array3d &&>;
-        { f.BE(x).E } -> std::same_as<muc::array3d &&>;
+        { f.BE(x).B } -> std::same_as<muc::array3d&&>;
+        { f.BE(x).E } -> std::same_as<muc::array3d&&>;
         { f.template B<muc::array3d>({}) } -> std::same_as<muc::array3d>;
         { f.template E<muc::array3d>({}) } -> std::same_as<muc::array3d>;
-        { f.template BE<muc::array3d>({}).B } -> std::same_as<muc::array3d &&>;
-        { f.template BE<muc::array3d>({}).E } -> std::same_as<muc::array3d &&>;
+        { f.template BE<muc::array3d>({}).B } -> std::same_as<muc::array3d&&>;
+        { f.template BE<muc::array3d>({}).E } -> std::same_as<muc::array3d&&>;
     };
 
 } // namespace Mustard::Detector::Field

--- a/src/Mustard/Geant4X/Process/MuoniumTransport.h++
+++ b/src/Mustard/Geant4X/Process/MuoniumTransport.h++
@@ -74,8 +74,8 @@ private:
     TransportStatus fTransportStatus;
     G4bool fIsExitingTargetVolume;
 
-    Math::Random::Xoshiro256Plus fXoshiro256Plus;
-    Math::Random::Gaussian3DDiagnoalFast<G4ThreeVector> fStandardGaussian3D;
+    Random::Xoshiro256Plus fXoshiro256Plus;
+    Random::Gaussian3DDiagnoalFast<G4ThreeVector> fStandardGaussian3D;
 
     typename MuoniumPhysicsMessenger<ATarget>::template Register<MuoniumTransport<ATarget>> fMessengerRegister;
 };

--- a/src/Mustard/Geant4X/Process/MuoniumTransport.inl
+++ b/src/Mustard/Geant4X/Process/MuoniumTransport.inl
@@ -127,8 +127,8 @@ auto MuoniumTransport<ATarget>::ProposeRandomFlight(const G4Track& track) -> voi
     fXoshiro256Plus.Seed(G4Random::getTheEngine()->operator unsigned int());
     do {
         // set free path
-        static_assert(Math::Random::ExponentialFast<double>::Stateless());
-        freePath = Math::Random::ExponentialFast{meanFreePath}(fXoshiro256Plus);
+        static_assert(Random::ExponentialFast<double>::Stateless());
+        freePath = Random::ExponentialFast{meanFreePath}(fXoshiro256Plus);
         // update flight length
         trueStepLength += freePath;
         // update time

--- a/src/Mustard/Math/Estimate.h++
+++ b/src/Mustard/Math/Estimate.h++
@@ -24,7 +24,7 @@
 #include <cmath>
 #include <numbers>
 
-namespace Mustard::Math {
+namespace Mustard::inline Math {
 
 /// @brief Represents a value with associated uncertainty for error propagation
 ///
@@ -256,4 +256,4 @@ inline auto atanh(const Estimate& a) -> Estimate {
     return {std::atanh(a.value), a.uncertainty / (1 - muc::pow(a.value, 2))};
 }
 
-} // namespace Mustard::Math
+} // namespace Mustard::inline Math

--- a/src/Mustard/Math/GeometryRepresentation.h++
+++ b/src/Mustard/Math/GeometryRepresentation.h++
@@ -18,18 +18,14 @@
 
 #pragma once
 
-#include "CLHEP/Vector/ThreeVector.h"
-#include "CLHEP/Vector/TwoVector.h"
+#include "Mustard/Math/Vector.h++"
 
 #include "muc/math"
 
 #include <cmath>
 #include <utility>
 
-namespace Mustard::Math {
-
-/// @brief 2D vector
-using Vector2D = CLHEP::Hep2Vector;
+namespace Mustard::inline Math {
 
 /// @brief 2D point representation
 using Point2D = Vector2D;
@@ -46,9 +42,6 @@ struct Line2D {
         return point + t * direction;
     }
 };
-
-/// @brief 3D vector
-using Vector3D = CLHEP::Hep3Vector;
 
 /// @brief 3D point representation
 using Point3D = Vector3D;
@@ -140,4 +133,4 @@ struct Helix {
     }
 };
 
-} // namespace Mustard::Math
+} // namespace Mustard::inline Math

--- a/src/Mustard/Math/MCIntegrationUtility.h++
+++ b/src/Mustard/Math/MCIntegrationUtility.h++
@@ -22,7 +22,7 @@
 
 #include "muc/array"
 
-namespace Mustard::Math {
+namespace Mustard::inline Math {
 
 /// @brief Monte Carlo integration internal state
 struct MCIntegrationState {
@@ -30,4 +30,4 @@ struct MCIntegrationState {
     unsigned long long n; ///< Sample size
 };
 
-} // namespace Mustard::Math
+} // namespace Mustard::inline Math

--- a/src/Mustard/Math/POCA.c++
+++ b/src/Mustard/Math/POCA.c++
@@ -27,7 +27,7 @@
 #include <algorithm>
 #include <cmath>
 
-namespace Mustard::Math {
+namespace Mustard::inline Math {
 
 auto POCA(const Line3D& line, const Point3D& point) -> LinePoint3DPOCAResult {
     const auto& [x1, d1]{line};
@@ -252,4 +252,4 @@ auto POCA(const Helix& helix, const Line3D& line, double phiLow, double phiUp,
     return HelixLinePOCAResult{poca1, poca2, doca};
 }
 
-} // namespace Mustard::Math
+} // namespace Mustard::inline Math

--- a/src/Mustard/Math/POCA.h++
+++ b/src/Mustard/Math/POCA.h++
@@ -24,7 +24,7 @@
 
 #include <optional>
 
-namespace Mustard::Math {
+namespace Mustard::inline Math {
 
 /// @brief Result of line-point POCA calculation
 struct LinePoint3DPOCAResult {
@@ -117,4 +117,4 @@ auto POCA(const Helix& helix, const Line3D& line, double phiLow, double phiUp,
           double absTol = muc::default_abs_tol<double>,
           double relTol = muc::default_rel_tol<double>) -> std::optional<HelixLinePOCAResult>;
 
-} // namespace Mustard::Math
+} // namespace Mustard::inline Math

--- a/src/Mustard/Math/Random/Distribution/Exponential.h++
+++ b/src/Mustard/Math/Random/Distribution/Exponential.h++
@@ -32,7 +32,7 @@
 #include <iomanip>
 #include <limits>
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -166,6 +166,6 @@ private:
 template<typename T>
 ExponentialFast(T) -> ExponentialFast<T>;
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution
 
 #include "Mustard/Math/Random/Distribution/Exponential.inl"

--- a/src/Mustard/Math/Random/Distribution/Exponential.inl
+++ b/src/Mustard/Math/Random/Distribution/Exponential.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -69,4 +69,4 @@ MUSTARD_ALWAYS_INLINE constexpr auto ExponentialFast<T>::Impl(auto& g, const Exp
     MUSTARD_MATH_RANDOM_DISTRIBUTION_EXPONENTIAL_GENERATOR_SNIPPET(Math::internal::FastLogOn01)
 }
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution

--- a/src/Mustard/Math/Random/Distribution/Gaussian.h++
+++ b/src/Mustard/Math/Random/Distribution/Gaussian.h++
@@ -29,7 +29,7 @@
 #include <concepts>
 #include <limits>
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -191,6 +191,6 @@ private:
 template<typename T, typename U>
 GaussianFast(T, U) -> GaussianFast<std::common_type_t<T, U>>;
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution
 
 #include "Mustard/Math/Random/Distribution/Gaussian.inl"

--- a/src/Mustard/Math/Random/Distribution/Gaussian.inl
+++ b/src/Mustard/Math/Random/Distribution/Gaussian.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -74,4 +74,4 @@ MUSTARD_ALWAYS_INLINE auto GaussianFast<T>::Impl(auto& g, const GaussianFastPara
 
 #undef MUSTARD_MATH_RANDOM_DISTRIBUTION_GAUSSIAN_GENERATOR_SNIPPET
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution

--- a/src/Mustard/Math/Random/Distribution/Gaussian2DDiagnoal.h++
+++ b/src/Mustard/Math/Random/Distribution/Gaussian2DDiagnoal.h++
@@ -35,7 +35,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -197,6 +197,6 @@ private:
 template<typename T, typename U>
 Gaussian2DDiagnoalFast(std::initializer_list<T>, std::initializer_list<U>) -> Gaussian2DDiagnoalFast<std::array<std::common_type_t<T, U>, 2>>;
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution
 
 #include "Mustard/Math/Random/Distribution/Gaussian2DDiagnoal.inl"

--- a/src/Mustard/Math/Random/Distribution/Gaussian2DDiagnoal.inl
+++ b/src/Mustard/Math/Random/Distribution/Gaussian2DDiagnoal.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -85,4 +85,4 @@ MUSTARD_ALWAYS_INLINE auto Gaussian2DDiagnoalFast<T>::Impl(auto& g, const Gaussi
 
 #undef MUSTARD_MATH_RANDOM_DISTRIBUTION_GAUSSIAN_2D_DIAGNOAL_GENERATOR_SNIPPET
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution

--- a/src/Mustard/Math/Random/Distribution/Gaussian3DDiagnoal.h++
+++ b/src/Mustard/Math/Random/Distribution/Gaussian3DDiagnoal.h++
@@ -32,7 +32,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -212,6 +212,6 @@ private:
 template<typename T, typename U, typename V>
 Gaussian3DDiagnoalFast(std::initializer_list<T>, std::initializer_list<U>, std::initializer_list<V>) -> Gaussian3DDiagnoalFast<std::array<std::common_type_t<T, U, V>, 3>>;
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution
 
 #include "Mustard/Math/Random/Distribution/Gaussian3DDiagnoal.inl"

--- a/src/Mustard/Math/Random/Distribution/Gaussian3DDiagnoal.inl
+++ b/src/Mustard/Math/Random/Distribution/Gaussian3DDiagnoal.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -95,4 +95,4 @@ MUSTARD_ALWAYS_INLINE auto Gaussian3DDiagnoalFast<T>::Impl(auto& g, const Gaussi
 
 #undef MUSTARD_MATH_RANDOM_DISTRIBUTION_GAUSSIAN_3D_DIAGNOAL_GENERATOR_SNIPPET
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution

--- a/src/Mustard/Math/Random/Distribution/Joint.h++
+++ b/src/Mustard/Math/Random/Distribution/Joint.h++
@@ -35,7 +35,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -175,6 +175,6 @@ Joint(Ps...) -> Joint<std::array<std::common_type_t<typename Ps::DistributionTyp
 template<typename... Ds>
 Joint(JointParameter<Ds...>) -> Joint<std::array<std::common_type_t<typename Ds::ResultType...>, sizeof...(Ds)>, Ds...>;
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution
 
 #include "Mustard/Math/Random/Distribution/Joint.inl"

--- a/src/Mustard/Math/Random/Distribution/Joint.inl
+++ b/src/Mustard/Math/Random/Distribution/Joint.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -153,4 +153,4 @@ auto JointInterface<ADerived, AParameter, T, Ds...>::StreamInput(std::basic_istr
     }(gslx::index_sequence_for<Ds...>());
 }
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution

--- a/src/Mustard/Math/Random/Distribution/Uniform.h++
+++ b/src/Mustard/Math/Random/Distribution/Uniform.h++
@@ -31,7 +31,7 @@
 #include <random>
 #include <type_traits>
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -184,6 +184,6 @@ public:
 template<typename T, typename U>
 UniformInteger(T, U) -> UniformInteger<std::common_type_t<T, U>>;
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution
 
 #include "Mustard/Math/Random/Distribution/Uniform.inl"

--- a/src/Mustard/Math/Random/Distribution/Uniform.inl
+++ b/src/Mustard/Math/Random/Distribution/Uniform.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -100,4 +100,4 @@ MUSTARD_ALWAYS_INLINE constexpr auto UniformInteger<T>::operator()(UniformRandom
     return std::uniform_int_distribution<T>{p.Infimum(), p.Supremum()}(g);
 }
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution

--- a/src/Mustard/Math/Random/Distribution/UniformDisk.h++
+++ b/src/Mustard/Math/Random/Distribution/UniformDisk.h++
@@ -36,7 +36,7 @@
 #include <concepts>
 #include <iomanip>
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -193,6 +193,6 @@ UniformDisk(T, U, V) -> UniformDisk<std::array<std::common_type_t<T, U, V>, 2>>;
 template<typename T>
 UniformDisk(T) -> UniformDisk<std::array<T, 2>>;
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution
 
 #include "Mustard/Math/Random/Distribution/UniformDisk.inl"

--- a/src/Mustard/Math/Random/Distribution/UniformDisk.inl
+++ b/src/Mustard/Math/Random/Distribution/UniformDisk.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -109,4 +109,4 @@ MUSTARD_ALWAYS_INLINE constexpr auto UniformDisk<T>::Impl(auto& g, const Uniform
 
 #undef MUSTARD_MATH_RANDOM_DISTRIBUTION_UNIFORM_DISK_GENERATOR
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution

--- a/src/Mustard/Math/Random/Distribution/UniformRectangle.h++
+++ b/src/Mustard/Math/Random/Distribution/UniformRectangle.h++
@@ -31,7 +31,7 @@
 #include <iomanip>
 #include <type_traits>
 
-namespace Mustard::Math::Random::inline Distribution {
+namespace Mustard::inline Math::Random::inline Distribution {
 
 namespace internal {
 
@@ -155,4 +155,4 @@ public:
 template<typename T, typename U>
 UniformIntegerRectangle(std::initializer_list<T>, std::initializer_list<U>) -> UniformIntegerRectangle<std::array<std::common_type_t<T, U>, 2>>;
 
-} // namespace Mustard::Math::Random::inline Distribution
+} // namespace Mustard::inline Math::Random::inline Distribution

--- a/src/Mustard/Math/Random/Generator/MT1993732.h++
+++ b/src/Mustard/Math/Random/Generator/MT1993732.h++
@@ -24,7 +24,7 @@
 
 #include <random>
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 class MT1993732 final : public UniformPseudoRandomBitGeneratorBase<MT1993732,
                                                                    std::mt19937::result_type,
@@ -48,6 +48,6 @@ private:
     std::mt19937 fMT;
 };
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator
 
 #include "Mustard/Math/Random/Generator/MT1993732.inl"

--- a/src/Mustard/Math/Random/Generator/MT1993732.inl
+++ b/src/Mustard/Math/Random/Generator/MT1993732.inl
@@ -16,10 +16,10 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 MT1993732::MT1993732(MT1993732::SeedType seed) :
     UniformPseudoRandomBitGeneratorBase{},
     fMT{seed} {}
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator

--- a/src/Mustard/Math/Random/Generator/MT1993764.h++
+++ b/src/Mustard/Math/Random/Generator/MT1993764.h++
@@ -24,7 +24,7 @@
 
 #include <random>
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 class MT1993764 final : public UniformPseudoRandomBitGeneratorBase<MT1993764,
                                                                    std::mt19937_64::result_type,
@@ -48,6 +48,6 @@ private:
     std::mt19937_64 fMT;
 };
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator
 
 #include "Mustard/Math/Random/Generator/MT1993764.inl"

--- a/src/Mustard/Math/Random/Generator/RandomDevice.h++
+++ b/src/Mustard/Math/Random/Generator/RandomDevice.h++
@@ -22,7 +22,7 @@
 
 #include <random>
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 class RandomDevice final : public UniformRandomBitGeneratorBase<RandomDevice,
                                                                 std::random_device::result_type> {
@@ -40,4 +40,4 @@ private:
     std::random_device fRD;
 };
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator

--- a/src/Mustard/Math/Random/Generator/SplitMix64.h++
+++ b/src/Mustard/Math/Random/Generator/SplitMix64.h++
@@ -28,7 +28,7 @@
 #include <limits>
 #include <ostream>
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 class SplitMix64 final : public UniformPseudoRandomBitGeneratorBase<SplitMix64,
                                                                     std::uint64_t,
@@ -52,6 +52,6 @@ private:
     ResultType fState;
 };
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator
 
 #include "Mustard/Math/Random/Generator/SplitMix64.inl"

--- a/src/Mustard/Math/Random/Generator/SplitMix64.inl
+++ b/src/Mustard/Math/Random/Generator/SplitMix64.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 constexpr SplitMix64::SplitMix64() :
     UniformPseudoRandomBitGeneratorBase{},
@@ -42,4 +42,4 @@ constexpr auto SplitMix64::Seed(SplitMix64::SeedType seed) -> void {
     (*this)();
 }
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator

--- a/src/Mustard/Math/Random/Generator/Xoshiro256Base.h++
+++ b/src/Mustard/Math/Random/Generator/Xoshiro256Base.h++
@@ -29,7 +29,7 @@
 #include <istream>
 #include <ostream>
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 template<typename ADerived>
 class Xoshiro256Base : public XoshiroBase<ADerived, 256> {
@@ -53,6 +53,6 @@ private:
     auto StreamInput(std::basic_istream<AChar>& is) & -> decltype(is);
 };
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator
 
 #include "Mustard/Math/Random/Generator/Xoshiro256Base.inl"

--- a/src/Mustard/Math/Random/Generator/Xoshiro256Base.inl
+++ b/src/Mustard/Math/Random/Generator/Xoshiro256Base.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 template<typename ADerived>
 constexpr Xoshiro256Base<ADerived>::Xoshiro256Base() : // clang-format off
@@ -63,4 +63,4 @@ auto Xoshiro256Base<ADerived>::StreamInput(std::basic_istream<AChar>& is) & -> d
               >> this->fState[3]; // clang-format on
 }
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator

--- a/src/Mustard/Math/Random/Generator/Xoshiro256Plus.h++
+++ b/src/Mustard/Math/Random/Generator/Xoshiro256Plus.h++
@@ -21,7 +21,7 @@
 #include "Mustard/Math/Random/Generator/Xoshiro256Base.h++"
 #include "Mustard/Utility/FunctionAttribute.h++"
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 class Xoshiro256Plus final : public Xoshiro256Base<Xoshiro256Plus> {
 public:
@@ -31,6 +31,6 @@ public:
     MUSTARD_ALWAYS_INLINE constexpr auto operator()() -> ResultType;
 };
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator
 
 #include "Mustard/Math/Random/Generator/Xoshiro256Plus.inl"

--- a/src/Mustard/Math/Random/Generator/Xoshiro256Plus.inl
+++ b/src/Mustard/Math/Random/Generator/Xoshiro256Plus.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 constexpr Xoshiro256Plus::Xoshiro256Plus(Xoshiro256Plus::SeedType seed) :
     Xoshiro256Base{seed} {}
@@ -27,4 +27,4 @@ MUSTARD_ALWAYS_INLINE constexpr auto Xoshiro256Plus::operator()() -> Xoshiro256P
     return result;
 }
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator

--- a/src/Mustard/Math/Random/Generator/Xoshiro256PlusPlus.h++
+++ b/src/Mustard/Math/Random/Generator/Xoshiro256PlusPlus.h++
@@ -23,7 +23,7 @@
 
 #include <bit>
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 class Xoshiro256PlusPlus final : public Xoshiro256Base<Xoshiro256PlusPlus> {
 public:
@@ -33,6 +33,6 @@ public:
     MUSTARD_ALWAYS_INLINE constexpr auto operator()() -> ResultType;
 };
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator
 
 #include "Mustard/Math/Random/Generator/Xoshiro256PlusPlus.inl"

--- a/src/Mustard/Math/Random/Generator/Xoshiro256PlusPlus.inl
+++ b/src/Mustard/Math/Random/Generator/Xoshiro256PlusPlus.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 constexpr Xoshiro256PlusPlus::Xoshiro256PlusPlus(Xoshiro256PlusPlus::SeedType seed) :
     Xoshiro256Base{seed} {}
@@ -27,4 +27,4 @@ MUSTARD_ALWAYS_INLINE constexpr auto Xoshiro256PlusPlus::operator()() -> Xoshiro
     return result;
 }
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator

--- a/src/Mustard/Math/Random/Generator/Xoshiro256StarStar.h++
+++ b/src/Mustard/Math/Random/Generator/Xoshiro256StarStar.h++
@@ -23,7 +23,7 @@
 
 #include <bit>
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 class Xoshiro256StarStar final : public Xoshiro256Base<Xoshiro256StarStar> {
 public:
@@ -33,6 +33,6 @@ public:
     MUSTARD_ALWAYS_INLINE constexpr auto operator()() -> ResultType;
 };
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator
 
 #include "Mustard/Math/Random/Generator/Xoshiro256StarStar.inl"

--- a/src/Mustard/Math/Random/Generator/Xoshiro256StarStar.inl
+++ b/src/Mustard/Math/Random/Generator/Xoshiro256StarStar.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 constexpr Xoshiro256StarStar::Xoshiro256StarStar(Xoshiro256StarStar::SeedType seed) :
     Xoshiro256Base{seed} {}
@@ -27,4 +27,4 @@ MUSTARD_ALWAYS_INLINE constexpr auto Xoshiro256StarStar::operator()() -> Xoshiro
     return result;
 }
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator

--- a/src/Mustard/Math/Random/Generator/Xoshiro512Base.h++
+++ b/src/Mustard/Math/Random/Generator/Xoshiro512Base.h++
@@ -29,7 +29,7 @@
 #include <istream>
 #include <ostream>
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 template<typename ADerived>
 class Xoshiro512Base : public XoshiroBase<ADerived, 512> {
@@ -53,6 +53,6 @@ private:
     auto StreamInput(std::basic_istream<AChar>& is) & -> decltype(is);
 };
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator
 
 #include "Mustard/Math/Random/Generator/Xoshiro512Base.inl"

--- a/src/Mustard/Math/Random/Generator/Xoshiro512Base.inl
+++ b/src/Mustard/Math/Random/Generator/Xoshiro512Base.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 template<typename ADerived>
 constexpr Xoshiro512Base<ADerived>::Xoshiro512Base() : // clang-format off
@@ -79,4 +79,4 @@ auto Xoshiro512Base<ADerived>::StreamInput(std::basic_istream<AChar>& is) & -> d
               >> this->fState[7]; // clang-format on
 }
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator

--- a/src/Mustard/Math/Random/Generator/Xoshiro512Plus.h++
+++ b/src/Mustard/Math/Random/Generator/Xoshiro512Plus.h++
@@ -21,7 +21,7 @@
 #include "Mustard/Math/Random/Generator/Xoshiro512Base.h++"
 #include "Mustard/Utility/FunctionAttribute.h++"
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 class Xoshiro512Plus final : public Xoshiro512Base<Xoshiro512Plus> {
 public:
@@ -31,6 +31,6 @@ public:
     MUSTARD_ALWAYS_INLINE constexpr auto operator()() -> ResultType;
 };
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator
 
 #include "Mustard/Math/Random/Generator/Xoshiro512Plus.inl"

--- a/src/Mustard/Math/Random/Generator/Xoshiro512Plus.inl
+++ b/src/Mustard/Math/Random/Generator/Xoshiro512Plus.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 constexpr Xoshiro512Plus::Xoshiro512Plus(Xoshiro512Plus::SeedType seed) :
     Xoshiro512Base{seed} {}
@@ -27,4 +27,4 @@ MUSTARD_ALWAYS_INLINE constexpr auto Xoshiro512Plus::operator()() -> Xoshiro512P
     return result;
 }
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator

--- a/src/Mustard/Math/Random/Generator/Xoshiro512PlusPlus.h++
+++ b/src/Mustard/Math/Random/Generator/Xoshiro512PlusPlus.h++
@@ -23,7 +23,7 @@
 
 #include <bit>
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 class Xoshiro512PlusPlus final : public Xoshiro512Base<Xoshiro512PlusPlus> {
 public:
@@ -33,6 +33,6 @@ public:
     MUSTARD_ALWAYS_INLINE constexpr auto operator()() -> ResultType;
 };
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator
 
 #include "Mustard/Math/Random/Generator/Xoshiro512PlusPlus.inl"

--- a/src/Mustard/Math/Random/Generator/Xoshiro512PlusPlus.inl
+++ b/src/Mustard/Math/Random/Generator/Xoshiro512PlusPlus.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 constexpr Xoshiro512PlusPlus::Xoshiro512PlusPlus(Xoshiro512PlusPlus::SeedType seed) :
     Xoshiro512Base{seed} {}
@@ -27,4 +27,4 @@ MUSTARD_ALWAYS_INLINE constexpr auto Xoshiro512PlusPlus::operator()() -> Xoshiro
     return result;
 }
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator

--- a/src/Mustard/Math/Random/Generator/Xoshiro512StarStar.h++
+++ b/src/Mustard/Math/Random/Generator/Xoshiro512StarStar.h++
@@ -23,7 +23,7 @@
 
 #include <bit>
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 class Xoshiro512StarStar final : public Xoshiro512Base<Xoshiro512StarStar> {
 public:
@@ -33,6 +33,6 @@ public:
     MUSTARD_ALWAYS_INLINE constexpr auto operator()() -> ResultType;
 };
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator
 
 #include "Mustard/Math/Random/Generator/Xoshiro512StarStar.inl"

--- a/src/Mustard/Math/Random/Generator/Xoshiro512StarStar.inl
+++ b/src/Mustard/Math/Random/Generator/Xoshiro512StarStar.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 constexpr Xoshiro512StarStar::Xoshiro512StarStar(Xoshiro512StarStar::SeedType seed) :
     Xoshiro512Base{seed} {}
@@ -27,4 +27,4 @@ MUSTARD_ALWAYS_INLINE constexpr auto Xoshiro512StarStar::operator()() -> Xoshiro
     return result;
 }
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator

--- a/src/Mustard/Math/Random/Generator/XoshiroBase.h++
+++ b/src/Mustard/Math/Random/Generator/XoshiroBase.h++
@@ -28,7 +28,7 @@
 #include <limits>
 #include <utility>
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 template<typename ADerived, std::size_t NBit>
     requires(NBit % 64 == 0)
@@ -50,6 +50,6 @@ protected:
     std::array<std::uint64_t, NBit / 64> fState;
 };
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator
 
 #include "Mustard/Math/Random/Generator/XoshiroBase.inl"

--- a/src/Mustard/Math/Random/Generator/XoshiroBase.inl
+++ b/src/Mustard/Math/Random/Generator/XoshiroBase.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random::inline Generator {
+namespace Mustard::inline Math::Random::inline Generator {
 
 template<typename ADerived, std::size_t NBit>
     requires(NBit % 64 == 0)
@@ -44,4 +44,4 @@ constexpr auto XoshiroBase<ADerived, NBit>::Seed(std::uint64_t seed) -> void {
     static_cast<ADerived*>(this)->Step();
 }
 
-} // namespace Mustard::Math::Random::inline Generator
+} // namespace Mustard::inline Math::Random::inline Generator

--- a/src/Mustard/Math/Random/RandomNumberDistribution.h++
+++ b/src/Mustard/Math/Random/RandomNumberDistribution.h++
@@ -28,7 +28,7 @@
 #include <ostream>
 #include <type_traits>
 
-namespace Mustard::Math::Random {
+namespace Mustard::inline Math::Random {
 
 /// @brief Sub-requirements on D::param_type of RandomNumberDistribution (a C++
 /// named requirements).
@@ -288,4 +288,4 @@ concept RandomNumberDistribution = requires(D d, const D x) {
     requires not std::convertible_to<typename D::ParameterType, D>;
 };
 
-} // namespace Mustard::Math::Random
+} // namespace Mustard::inline Math::Random

--- a/src/Mustard/Math/Random/RandomNumberDistributionBase.h++
+++ b/src/Mustard/Math/Random/RandomNumberDistributionBase.h++
@@ -23,7 +23,7 @@
 
 #include <type_traits>
 
-namespace Mustard::Math::Random {
+namespace Mustard::inline Math::Random {
 
 template<typename ADerived, typename ADistribution>
 class DistributionParameterBase {
@@ -65,6 +65,6 @@ public:
     constexpr auto operator<=>(const RandomNumberDistributionBase&) const -> auto = delete;
 };
 
-} // namespace Mustard::Math::Random
+} // namespace Mustard::inline Math::Random
 
 #include "Mustard/Math/Random/RandomNumberDistributionBase.inl"

--- a/src/Mustard/Math/Random/RandomNumberDistributionBase.inl
+++ b/src/Mustard/Math/Random/RandomNumberDistributionBase.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random {
+namespace Mustard::inline Math::Random {
 
 template<typename ADerived, typename ADistribution>
 constexpr DistributionParameterBase<ADerived, ADistribution>::DistributionParameterBase() {
@@ -31,4 +31,4 @@ constexpr RandomNumberDistributionBase<ADerived, AParameter, T>::RandomNumberDis
     static_assert(std::is_final_v<ADerived>);
 }
 
-} // namespace Mustard::Math::Random
+} // namespace Mustard::inline Math::Random

--- a/src/Mustard/Math/Random/UniformPseudoRandomBitGenerator.h++
+++ b/src/Mustard/Math/Random/UniformPseudoRandomBitGenerator.h++
@@ -26,7 +26,7 @@
 #include <random>
 #include <type_traits>
 
-namespace Mustard::Math::Random {
+namespace Mustard::inline Math::Random {
 
 /// @brief Concept of uniform pseudo random bit generator.
 template<typename G>
@@ -59,4 +59,4 @@ concept UniformPseudoRandomBitGenerator = requires(G& g) {
     requires muc::stream_ioable<G>;
 };
 
-} // namespace Mustard::Math::Random
+} // namespace Mustard::inline Math::Random

--- a/src/Mustard/Math/Random/UniformPseudoRandomBitGeneratorBase.h++
+++ b/src/Mustard/Math/Random/UniformPseudoRandomBitGeneratorBase.h++
@@ -24,7 +24,7 @@
 #include <concepts>
 #include <utility>
 
-namespace Mustard::Math::Random {
+namespace Mustard::inline Math::Random {
 
 /// @brief Well-formed derivation of this class fulfills
 /// the concept UniformPseudoRandomBitGenerator.
@@ -43,6 +43,6 @@ public:
     auto seed(SeedType s) -> void { return static_cast<ADerived*>(this)->Seed(s); }
 };
 
-} // namespace Mustard::Math::Random
+} // namespace Mustard::inline Math::Random
 
 #include "Mustard/Math/Random/UniformPseudoRandomBitGeneratorBase.inl"

--- a/src/Mustard/Math/Random/UniformPseudoRandomBitGeneratorBase.inl
+++ b/src/Mustard/Math/Random/UniformPseudoRandomBitGeneratorBase.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random {
+namespace Mustard::inline Math::Random {
 
 template<typename ADerived, std::unsigned_integral AResult, std::unsigned_integral ASeed>
 constexpr UniformPseudoRandomBitGeneratorBase<ADerived, AResult, ASeed>::UniformPseudoRandomBitGeneratorBase() :
@@ -25,4 +25,4 @@ constexpr UniformPseudoRandomBitGeneratorBase<ADerived, AResult, ASeed>::Uniform
     static_assert(std::is_final_v<ADerived>);
 }
 
-} // namespace Mustard::Math::Random
+} // namespace Mustard::inline Math::Random

--- a/src/Mustard/Math/Random/UniformRandomBitGenerator.h++
+++ b/src/Mustard/Math/Random/UniformRandomBitGenerator.h++
@@ -22,7 +22,7 @@
 #include <random>
 #include <type_traits>
 
-namespace Mustard::Math::Random {
+namespace Mustard::inline Math::Random {
 
 /// @brief Concept of uniform random bit generator.
 template<typename G>
@@ -45,4 +45,4 @@ concept UniformRandomBitGenerator = requires(G g) {
     requires std::default_initializable<G>;
 };
 
-} // namespace Mustard::Math::Random
+} // namespace Mustard::inline Math::Random

--- a/src/Mustard/Math/Random/UniformRandomBitGeneratorBase.h++
+++ b/src/Mustard/Math/Random/UniformRandomBitGeneratorBase.h++
@@ -22,7 +22,7 @@
 
 #include <concepts>
 
-namespace Mustard::Math::Random {
+namespace Mustard::inline Math::Random {
 
 /// @brief Well-formed derivation of this class fulfills
 /// concepts UniformRandomBitGenerator and STDUniformRandomBitGenerator
@@ -46,6 +46,6 @@ public:
     constexpr bool operator==(const UniformRandomBitGeneratorBase&) const = default;
 };
 
-} // namespace Mustard::Math::Random
+} // namespace Mustard::inline Math::Random
 
 #include "Mustard/Math/Random/UniformRandomBitGeneratorBase.inl"

--- a/src/Mustard/Math/Random/UniformRandomBitGeneratorBase.inl
+++ b/src/Mustard/Math/Random/UniformRandomBitGeneratorBase.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math::Random {
+namespace Mustard::inline Math::Random {
 
 template<typename ADerived, std::unsigned_integral AResult>
 constexpr UniformRandomBitGeneratorBase<ADerived, AResult>::UniformRandomBitGeneratorBase() {
@@ -24,4 +24,4 @@ constexpr UniformRandomBitGeneratorBase<ADerived, AResult>::UniformRandomBitGene
     static_assert(std::is_final_v<ADerived>);
 }
 
-} // namespace Mustard::Math::Random
+} // namespace Mustard::inline Math::Random

--- a/src/Mustard/Math/Statistic.h++
+++ b/src/Mustard/Math/Statistic.h++
@@ -33,7 +33,7 @@
 #include <ranges>
 #include <stdexcept>
 
-namespace Mustard::Math {
+namespace Mustard::inline Math {
 
 template<int N>
     requires(N > 0)
@@ -192,6 +192,6 @@ private:
     double fSumW2;
 };
 
-} // namespace Mustard::Math
+} // namespace Mustard::inline Math
 
 #include "Mustard/Math/Statistic.inl"

--- a/src/Mustard/Math/Statistic.inl
+++ b/src/Mustard/Math/Statistic.inl
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::Math {
+namespace Mustard::inline Math {
 
 constexpr Statistic<1>::Statistic() :
     fSumWX{},
@@ -297,4 +297,4 @@ auto Statistic<N>::Kurtosis() const -> Eigen::Vector<double, N> {
     return CentralMoment<4>() / variance.cwiseProduct(variance);
 }
 
-} // namespace Mustard::Math
+} // namespace Mustard::inline Math

--- a/src/Mustard/Math/Transform.h++
+++ b/src/Mustard/Math/Transform.h++
@@ -1,0 +1,72 @@
+// -*- C++ -*-
+//
+// Copyright (C) 2020-2025  Mustard developers
+//
+// This file is part of Mustard, an offline software framework for HEP experiments.
+//
+// Mustard is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// Mustard is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Mustard. If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "CLHEP/Vector/AxisAngle.h"
+#include "CLHEP/Vector/Boost.h"
+#include "CLHEP/Vector/BoostX.h"
+#include "CLHEP/Vector/BoostY.h"
+#include "CLHEP/Vector/BoostZ.h"
+#include "CLHEP/Vector/EulerAngles.h"
+#include "CLHEP/Vector/LorentzRotation.h"
+#include "CLHEP/Vector/Rotation.h"
+#include "CLHEP/Vector/RotationX.h"
+#include "CLHEP/Vector/RotationY.h"
+#include "CLHEP/Vector/RotationZ.h"
+
+// We use CLHEP vector as default vector types in Mustard.
+
+namespace Mustard::inline Math {
+
+/// @brief Generic boost
+using Boost = CLHEP::HepBoost;
+
+/// @brief Boost along x-axis
+using BoostX = CLHEP::HepBoostX;
+
+/// @brief Boost along y-axis
+using BoostY = CLHEP::HepBoostY;
+
+/// @brief Boost along z-axis
+using BoostZ = CLHEP::HepBoostZ;
+
+/// @brief Generic rotation
+using Rotation = CLHEP::HepRotation;
+
+/// @brief Rotation around x-axis
+using RotationX = CLHEP::HepRotationX;
+
+/// @brief Rotation around y-axis
+using RotationY = CLHEP::HepRotationY;
+
+/// @brief Rotation around z-axis
+using RotationZ = CLHEP::HepRotationZ;
+
+/// @brief Generic Lorentz transformation (rotation + boost)
+using LorentzRotation = CLHEP::HepLorentzRotation;
+
+// below are helper classes for constructing transformation
+
+/// @brief Euler angles (phi, theta, psi) in the z-y-z convention
+using EulerAngles = CLHEP::HepEulerAngles;
+
+/// @brief Axis-angle representation of a rotation
+using AxisAngle = CLHEP::HepAxisAngle;
+
+} // namespace Mustard::inline Math

--- a/src/Mustard/Math/Vector.h++
+++ b/src/Mustard/Math/Vector.h++
@@ -16,10 +16,23 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
-namespace Mustard::inline Math::Random::inline Generator {
+#pragma once
 
-MT1993764::MT1993764(MT1993764::SeedType seed) :
-    UniformPseudoRandomBitGeneratorBase{},
-    fMT{seed} {}
+#include "CLHEP/Vector/LorentzVector.h"
+#include "CLHEP/Vector/ThreeVector.h"
+#include "CLHEP/Vector/TwoVector.h"
 
-} // namespace Mustard::inline Math::Random::inline Generator
+// We use CLHEP vector as default vector types in Mustard.
+
+namespace Mustard::inline Math {
+
+/// @brief 2D vector
+using Vector2D = CLHEP::Hep2Vector;
+
+/// @brief 3D vector
+using Vector3D = CLHEP::Hep3Vector;
+
+/// @brief Lorentz vector
+using VectorLor = CLHEP::HepLorentzVector;
+
+} // namespace Mustard::inline Math

--- a/src/Mustard/Math/internal/FastLogOn01.h++
+++ b/src/Mustard/Math/internal/FastLogOn01.h++
@@ -33,7 +33,7 @@
 #include <limits>
 #include <numbers>
 
-namespace Mustard::Math::internal {
+namespace Mustard::inline Math::internal {
 
 template<std::floating_point T>
 MUSTARD_ALWAYS_INLINE constexpr auto FastLogOn01(T x) -> auto {
@@ -62,4 +62,4 @@ MUSTARD_ALWAYS_INLINE constexpr auto FastLogOn01(T x) -> auto {
     }
 }
 
-} // namespace Mustard::Math::internal
+} // namespace Mustard::inline Math::internal

--- a/src/Mustard/Parallel/ReseedRandomEngine.c++
+++ b/src/Mustard/Parallel/ReseedRandomEngine.c++
@@ -65,9 +65,9 @@ auto MasterMakeUniqueSeedSeries(auto xsr256Seed) -> muc::flat_hash_set<T> {
     const auto worldComm{mplr::comm_world()};
     Expects(worldComm.rank() == 0);
 
-    static_assert(std::same_as<Math::Random::Xoshiro256PlusPlus::SeedType, std::uint64_t>);
-    Math::Random::Xoshiro256PlusPlus xsr256{std::bit_cast<std::uint64_t>(xsr256Seed)};
-    Math::Random::Uniform<T> uniform{1, std::numeric_limits<T>::max() - 1}; // not 0x00...00 and not 0xff...ff
+    static_assert(std::same_as<Random::Xoshiro256PlusPlus::SeedType, std::uint64_t>);
+    Random::Xoshiro256PlusPlus xsr256{std::bit_cast<std::uint64_t>(xsr256Seed)};
+    Random::Uniform<T> uniform{1, std::numeric_limits<T>::max() - 1}; // not 0x00...00 and not 0xff...ff
 
     muc::flat_hash_set<T> uniqueSeeds;
     const auto worldSize{worldComm.size()};

--- a/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.h++
+++ b/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.h++
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "Mustard/Math/Random/Distribution/Gaussian.h++"
+#include "Mustard/Math/Vector.h++"
 #include "Mustard/Physics/Generator/MCMCGenerator.h++"
 #include "Mustard/Physics/QFT/MatrixElement.h++"
 #include "Mustard/Utility/VectorAssign.h++"
@@ -87,7 +88,7 @@ public:
     /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @note This overload is only enabled for polarized decay
-    AdaptiveMTMGenerator(const InitialStateMomenta& pI, CLHEP::Hep3Vector polarization,
+    AdaptiveMTMGenerator(const InitialStateMomenta& pI, Vector3D polarization,
                          const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                          std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {})
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
@@ -99,7 +100,7 @@ public:
     /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @note This overload is only enabled for polarized scattering
-    AdaptiveMTMGenerator(const InitialStateMomenta& pI, const std::array<CLHEP::Hep3Vector, M>& polarization,
+    AdaptiveMTMGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
                          const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                          std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {})
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
@@ -124,7 +125,7 @@ private:
     auto NextEventImpl(CLHEP::HepRandomEngine& rng, double burnInStepSize = 0) -> bool;
 
 private:
-    Math::Random::Gaussian<double> fGaussian;                                      ///< Gaussian distribution
+    Random::Gaussian<double> fGaussian;                                            ///< Gaussian distribution
     unsigned long long fIteration;                                                 ///< Current iteration count
     double fLearningRate;                                                          ///< Learning rate for adaptation
     Eigen::Vector<double, MarkovChain::dim> fRunningMean;                          ///< Running mean of states

--- a/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.inl
+++ b/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.inl
@@ -30,7 +30,7 @@ AdaptiveMTMGenerator<M, N, A>::AdaptiveMTMGenerator(const InitialStateMomenta& p
     fProposalSigma{} {}
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-AdaptiveMTMGenerator<M, N, A>::AdaptiveMTMGenerator(const InitialStateMomenta& pI, CLHEP::Hep3Vector polarization,
+AdaptiveMTMGenerator<M, N, A>::AdaptiveMTMGenerator(const InitialStateMomenta& pI, Vector3D polarization,
                                                     const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                                     std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize) // clang-format off
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> : // clang-format on
@@ -43,7 +43,7 @@ AdaptiveMTMGenerator<M, N, A>::AdaptiveMTMGenerator(const InitialStateMomenta& p
     fProposalSigma{} {}
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-AdaptiveMTMGenerator<M, N, A>::AdaptiveMTMGenerator(const InitialStateMomenta& pI, const std::array<CLHEP::Hep3Vector, M>& polarization,
+AdaptiveMTMGenerator<M, N, A>::AdaptiveMTMGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
                                                     const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                                     std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize) // clang-format off
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) : // clang-format on

--- a/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.h++
+++ b/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.h++
@@ -20,6 +20,7 @@
 
 #include "Mustard/IO/PrettyLog.h++"
 #include "Mustard/Math/Random/Distribution/Gaussian.h++"
+#include "Mustard/Math/Vector.h++"
 #include "Mustard/Physics/Generator/MCMCGenerator.h++"
 #include "Mustard/Physics/QFT/MatrixElement.h++"
 
@@ -86,7 +87,7 @@ public:
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     /// @note This overload is only enabled for polarized decay
-    ClassicalMetropolisGenerator(const InitialStateMomenta& pI, CLHEP::Hep3Vector polarization,
+    ClassicalMetropolisGenerator(const InitialStateMomenta& pI, Vector3D polarization,
                                  const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                  std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {},
                                  std::optional<double> stepSize = {})
@@ -100,7 +101,7 @@ public:
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     /// @note This overload is only enabled for polarized scattering
-    ClassicalMetropolisGenerator(const InitialStateMomenta& pI, const std::array<CLHEP::Hep3Vector, M>& polarization,
+    ClassicalMetropolisGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
                                  const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                  std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {},
                                  std::optional<double> stepSize = {})
@@ -123,8 +124,8 @@ private:
     virtual auto NextEvent(CLHEP::HepRandomEngine& rng) -> bool override;
 
 private:
-    Math::Random::Gaussian<double> fGaussian; ///< Gaussian distribution
-    double fStepSize;                         ///< Step scale along one direction in random state space
+    Random::Gaussian<double> fGaussian; ///< Gaussian distribution
+    double fStepSize;                   ///< Step scale along one direction in random state space
 
     static inline const auto fgScalingFactor{2.38 / std::sqrt(MarkovChain::dim)}; ///< Step size scaling factor
 };

--- a/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.inl
+++ b/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.inl
@@ -31,7 +31,7 @@ ClassicalMetropolisGenerator<M, N, A>::ClassicalMetropolisGenerator(const Initia
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-ClassicalMetropolisGenerator<M, N, A>::ClassicalMetropolisGenerator(const InitialStateMomenta& pI, CLHEP::Hep3Vector polarization,
+ClassicalMetropolisGenerator<M, N, A>::ClassicalMetropolisGenerator(const InitialStateMomenta& pI, Vector3D polarization,
                                                                     const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                                                     std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize,
                                                                     std::optional<double> stepSize) // clang-format off
@@ -45,7 +45,7 @@ ClassicalMetropolisGenerator<M, N, A>::ClassicalMetropolisGenerator(const Initia
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-ClassicalMetropolisGenerator<M, N, A>::ClassicalMetropolisGenerator(const InitialStateMomenta& pI, const std::array<CLHEP::Hep3Vector, M>& polarization,
+ClassicalMetropolisGenerator<M, N, A>::ClassicalMetropolisGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
                                                                     const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                                                     std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize,
                                                                     std::optional<double> stepSize) // clang-format off

--- a/src/Mustard/Physics/Generator/EventGenerator.h++
+++ b/src/Mustard/Physics/Generator/EventGenerator.h++
@@ -18,10 +18,10 @@
 
 #pragma once
 
+#include "Mustard/Math/Vector.h++"
+
 #include "CLHEP/Random/Random.h"
 #include "CLHEP/Random/RandomEngine.h"
-#include "CLHEP/Vector/LorentzVector.h"
-#include "CLHEP/Vector/ThreeVector.h"
 
 #include "muc/numeric"
 
@@ -61,10 +61,10 @@ template<int M, int N>
 class EventGenerator<M, N> {
 public:
     /// @brief Initial-state 4-momentum (or container type when M>1)
-    using InitialStateMomenta = std::conditional_t<M == 1, CLHEP::HepLorentzVector,
-                                                   std::array<CLHEP::HepLorentzVector, M>>;
+    using InitialStateMomenta = std::conditional_t<M == 1, VectorLor,
+                                                   std::array<VectorLor, M>>;
     /// @brief Final-state 4-momentum container type
-    using FinalStateMomenta = std::array<CLHEP::HepLorentzVector, N>;
+    using FinalStateMomenta = std::array<VectorLor, N>;
     /// @brief Generated event type
     struct Event {
         double weight;            ///< Event weight
@@ -99,7 +99,7 @@ protected:
     /// @brief Calculate boost from c.m. frame to lab frame
     /// @param pI Initial-state 4-momenta
     /// @return Boost from c.m. frame to lab frame
-    static auto CalculateBoost(const InitialStateMomenta& pI) -> CLHEP::Hep3Vector;
+    static auto CalculateBoost(const InitialStateMomenta& pI) -> Vector3D;
     /// @brief Boost initial state to c.m. frame
     ///
     /// Transforms initial-state momenta to c.m. frame:
@@ -111,7 +111,7 @@ protected:
     ///
     /// @note Return value should be saved for `BoostToLabFrame` call
     /// @warning Always called before event generation in c.m. frame
-    [[nodiscard]] static auto BoostToCMFrame(InitialStateMomenta& pI) -> CLHEP::Hep3Vector;
+    [[nodiscard]] static auto BoostToCMFrame(InitialStateMomenta& pI) -> Vector3D;
     /// @brief Boost final state to lab frame
     ///
     /// Applies inverse boost to return final state from c.m. frame to lab frame.
@@ -121,7 +121,7 @@ protected:
     ///
     /// @note Must use the β returned by `BoostToCMFrame` for correct transformation
     /// @warning Always called after event generation in c.m. frame
-    static auto BoostToLabFrame(CLHEP::Hep3Vector beta, FinalStateMomenta& pF) -> void;
+    static auto BoostToLabFrame(Vector3D beta, FinalStateMomenta& pF) -> void;
 };
 
 template<int M, int N, int D>

--- a/src/Mustard/Physics/Generator/EventGenerator.inl
+++ b/src/Mustard/Physics/Generator/EventGenerator.inl
@@ -38,7 +38,7 @@ auto EventGenerator<M, N>::CalculateCMEnergy(const InitialStateMomenta& pI) -> d
 }
 
 template<int M, int N>
-auto EventGenerator<M, N>::CalculateBoost(const InitialStateMomenta& pI) -> CLHEP::Hep3Vector {
+auto EventGenerator<M, N>::CalculateBoost(const InitialStateMomenta& pI) -> Vector3D {
     if constexpr (M == 1) {
         return pI.boostVector();
     } else {
@@ -47,10 +47,10 @@ auto EventGenerator<M, N>::CalculateBoost(const InitialStateMomenta& pI) -> CLHE
 }
 
 template<int M, int N>
-auto EventGenerator<M, N>::BoostToCMFrame(InitialStateMomenta& pI) -> CLHEP::Hep3Vector {
+auto EventGenerator<M, N>::BoostToCMFrame(InitialStateMomenta& pI) -> Vector3D {
     const auto beta{CalculateBoost(pI)};
     if constexpr (M == 1) {
-        pI = CLHEP::HepLorentzVector{pI.m()};
+        pI = VectorLor{pI.m()};
     } else {
         std::ranges::for_each(pI, [b = -beta](auto&& p) { p.boost(b); });
     }
@@ -58,7 +58,7 @@ auto EventGenerator<M, N>::BoostToCMFrame(InitialStateMomenta& pI) -> CLHEP::Hep
 }
 
 template<int M, int N>
-auto EventGenerator<M, N>::BoostToLabFrame(CLHEP::Hep3Vector beta, FinalStateMomenta& pF) -> void {
+auto EventGenerator<M, N>::BoostToLabFrame(Vector3D beta, FinalStateMomenta& pF) -> void {
     std::ranges::for_each(pF, [&beta](auto&& p) { p.boost(beta); });
 }
 

--- a/src/Mustard/Physics/Generator/GENBOD.h++
+++ b/src/Mustard/Physics/Generator/GENBOD.h++
@@ -19,12 +19,12 @@
 #pragma once
 
 #include "Mustard/IO/PrettyLog.h++"
+#include "Mustard/Math/Vector.h++"
 #include "Mustard/Physics/Generator/VersatileEventGenerator.h++"
 #include "Mustard/Utility/FunctionAttribute.h++"
 #include "Mustard/Utility/MathConstant.h++"
 
 #include "CLHEP/Units/SystemOfUnits.h"
-#include "CLHEP/Vector/LorentzVector.h"
 
 #include "muc/math"
 #include "muc/numeric"

--- a/src/Mustard/Physics/Generator/M2ENNEEGenerator.c++
+++ b/src/Mustard/Physics/Generator/M2ENNEEGenerator.c++
@@ -32,7 +32,7 @@ namespace Mustard::inline Physics::inline Generator {
 
 using namespace PhysicalConstant;
 
-M2ENNEEGenerator::M2ENNEEGenerator(std::string_view parent, CLHEP::Hep3Vector momentum, CLHEP::Hep3Vector polarization,
+M2ENNEEGenerator::M2ENNEEGenerator(std::string_view parent, Vector3D momentum, Vector3D polarization,
                                    std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize,
                                    std::optional<double> stepSize, std::optional<QFT::MSqM2ENNEE::Ver> mSqVer) :
     MultipleTryMetropolisGenerator{{}, polarization, {}, {}, std::move(thinningRatio), acfSampleSize.value_or(40000), stepSize.value_or(0.1)} {
@@ -55,7 +55,7 @@ auto M2ENNEEGenerator::Parent(std::string_view parent) -> void {
     }
 }
 
-auto M2ENNEEGenerator::ParentMomentum(CLHEP::Hep3Vector momentum) -> void {
+auto M2ENNEEGenerator::ParentMomentum(Vector3D momentum) -> void {
     const auto energy{std::sqrt(momentum.mag2() + muc::pow(muon_mass_c2, 2))};
     ISMomenta({energy, momentum});
 }

--- a/src/Mustard/Physics/Generator/M2ENNEEGenerator.h++
+++ b/src/Mustard/Physics/Generator/M2ENNEEGenerator.h++
@@ -18,10 +18,9 @@
 
 #pragma once
 
+#include "Mustard/Math/Vector.h++"
 #include "Mustard/Physics/Generator/MultipleTryMetropolisGenerator.h++"
 #include "Mustard/Physics/QFT/MSqM2ENNEE.h++"
-
-#include "CLHEP/Vector/ThreeVector.h"
 
 #include <optional>
 #include <string_view>
@@ -42,7 +41,7 @@ public:
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     /// @param mSqVer The matrix element version
-    M2ENNEEGenerator(std::string_view parent, CLHEP::Hep3Vector momentum, CLHEP::Hep3Vector polarization,
+    M2ENNEEGenerator(std::string_view parent, Vector3D momentum, Vector3D polarization,
                      std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {},
                      std::optional<double> stepSize = {}, std::optional<QFT::MSqM2ENNEE::Ver> mSqVer = {});
 
@@ -56,7 +55,7 @@ public:
     auto Parent(std::string_view parent) -> void;
     /// @brief Set parent momentum
     /// @param momentum Muon momentum
-    auto ParentMomentum(CLHEP::Hep3Vector momentum) -> void;
+    auto ParentMomentum(Vector3D momentum) -> void;
 };
 
 } // namespace Mustard::inline Physics::inline Generator

--- a/src/Mustard/Physics/Generator/M2ENNEGenerator.c++
+++ b/src/Mustard/Physics/Generator/M2ENNEGenerator.c++
@@ -32,7 +32,7 @@ namespace Mustard::inline Physics::inline Generator {
 
 using namespace PhysicalConstant;
 
-M2ENNEGenerator::M2ENNEGenerator(std::string_view parent, CLHEP::Hep3Vector momentum,
+M2ENNEGenerator::M2ENNEGenerator(std::string_view parent, Vector3D momentum,
                                  std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize,
                                  std::optional<double> stepSize) :
     MultipleTryMetropolisGenerator{{}, {}, {}, thinningRatio, acfSampleSize.value_or(100000), stepSize.value_or(0.1)} {
@@ -51,7 +51,7 @@ auto M2ENNEGenerator::Parent(std::string_view parent) -> void {
     }
 }
 
-auto M2ENNEGenerator::ParentMomentum(CLHEP::Hep3Vector momentum) -> void {
+auto M2ENNEGenerator::ParentMomentum(Vector3D momentum) -> void {
     const auto energy{std::sqrt(momentum.mag2() + muc::pow(muonium_mass_c2, 2))};
     ISMomenta({energy, momentum});
 }

--- a/src/Mustard/Physics/Generator/M2ENNEGenerator.h++
+++ b/src/Mustard/Physics/Generator/M2ENNEGenerator.h++
@@ -21,8 +21,6 @@
 #include "Mustard/Physics/Generator/MultipleTryMetropolisGenerator.h++"
 #include "Mustard/Physics/QFT/MSqM2ENNE.h++"
 
-#include "CLHEP/Vector/ThreeVector.h"
-
 #include <optional>
 #include <string_view>
 
@@ -40,7 +38,7 @@ public:
     /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
-    M2ENNEGenerator(std::string_view parent, CLHEP::Hep3Vector momentum,
+    M2ENNEGenerator(std::string_view parent, Vector3D momentum,
                     std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {},
                     std::optional<double> stepSize = {});
 
@@ -50,7 +48,7 @@ public:
     auto Parent(std::string_view parent) -> void;
     /// @brief Set parent momentum
     /// @param momentum Muonium momentum
-    auto ParentMomentum(CLHEP::Hep3Vector momentum) -> void;
+    auto ParentMomentum(Vector3D momentum) -> void;
 };
 
 } // namespace Mustard::inline Physics::inline Generator

--- a/src/Mustard/Physics/Generator/M2ENNGGGenerator.c++
+++ b/src/Mustard/Physics/Generator/M2ENNGGGenerator.c++
@@ -32,7 +32,7 @@ namespace Mustard::inline Physics::inline Generator {
 
 using namespace PhysicalConstant;
 
-M2ENNGGGenerator::M2ENNGGGenerator(std::string_view parent, CLHEP::Hep3Vector momentum, CLHEP::Hep3Vector polarization, double irCut,
+M2ENNGGGenerator::M2ENNGGGenerator(std::string_view parent, Vector3D momentum, Vector3D polarization, double irCut,
                                    std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize,
                                    std::optional<double> stepSize) :
     MultipleTryMetropolisGenerator{{}, polarization, {}, {}, std::move(thinningRatio), acfSampleSize.value_or(200000), stepSize.value_or(0.1)} {
@@ -53,7 +53,7 @@ auto M2ENNGGGenerator::Parent(std::string_view parent) -> void {
     }
 }
 
-auto M2ENNGGGenerator::ParentMomentum(CLHEP::Hep3Vector momentum) -> void {
+auto M2ENNGGGenerator::ParentMomentum(Vector3D momentum) -> void {
     const auto energy{std::sqrt(momentum.mag2() + muc::pow(muon_mass_c2, 2))};
     ISMomenta({energy, momentum});
 }

--- a/src/Mustard/Physics/Generator/M2ENNGGGenerator.h++
+++ b/src/Mustard/Physics/Generator/M2ENNGGGenerator.h++
@@ -18,10 +18,9 @@
 
 #pragma once
 
+#include "Mustard/Math/Vector.h++"
 #include "Mustard/Physics/Generator/MultipleTryMetropolisGenerator.h++"
 #include "Mustard/Physics/QFT/MSqM2ENNGG.h++"
-
-#include "CLHEP/Vector/ThreeVector.h"
 
 #include <optional>
 #include <string_view>
@@ -42,7 +41,7 @@ public:
     /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
-    M2ENNGGGenerator(std::string_view parent, CLHEP::Hep3Vector momentum, CLHEP::Hep3Vector polarization, double irCut,
+    M2ENNGGGenerator(std::string_view parent, Vector3D momentum, Vector3D polarization, double irCut,
                      std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {},
                      std::optional<double> stepSize = {});
 
@@ -52,7 +51,7 @@ public:
     auto Parent(std::string_view parent) -> void;
     /// @brief Set parent momentum
     /// @param momentum Muon momentum
-    auto ParentMomentum(CLHEP::Hep3Vector momentum) -> void;
+    auto ParentMomentum(Vector3D momentum) -> void;
     /// @brief Set IR cut for final-state photons
     /// @param irCut IR cut for final-state photons
     auto IRCut(double irCut) -> void;

--- a/src/Mustard/Physics/Generator/MCMCGenerator.h++
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.h++
@@ -20,6 +20,7 @@
 
 #include "Mustard/Env/BasicEnv.h++"
 #include "Mustard/IO/PrettyLog.h++"
+#include "Mustard/Math/Vector.h++"
 #include "Mustard/Parallel/ReseedRandomEngine.h++"
 #include "Mustard/Physics/Generator/GENBOD.h++"
 #include "Mustard/Physics/Generator/MatrixElementBasedGenerator.h++"
@@ -29,7 +30,6 @@
 
 #include "CLHEP/Random/Random.h"
 #include "CLHEP/Random/RandomEngine.h"
-#include "CLHEP/Vector/ThreeVector.h"
 
 #include "Eigen/Dense"
 
@@ -124,7 +124,7 @@ public:
     /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @note This overload is only enabled for polarized decay
-    MCMCGenerator(const InitialStateMomenta& pI, CLHEP::Hep3Vector polarization,
+    MCMCGenerator(const InitialStateMomenta& pI, Vector3D polarization,
                   const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                   std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {})
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
@@ -136,43 +136,43 @@ public:
     /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @note This overload is only enabled for polarized scattering
-    MCMCGenerator(const InitialStateMomenta& pI, const std::array<CLHEP::Hep3Vector, M>& polarization,
+    MCMCGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
                   const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                   std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {})
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
     /// @brief Get polarization vector
     /// @note This overload is only enabled for polarized decay
-    auto InitialStatePolarization() const -> CLHEP::Hep3Vector
+    auto InitialStatePolarization() const -> Vector3D
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
     /// @brief Get polarization vector
     /// @param i Particle index (0 ≤ i < M)
     /// @note This overload is only enabled for polarized scattering
-    auto InitialStatePolarization(int i) const -> CLHEP::Hep3Vector
+    auto InitialStatePolarization(int i) const -> Vector3D
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
     /// @brief Get all polarization vectors
     /// @note This overload is only enabled for polarized scattering
-    auto InitialStatePolarization() const -> const std::array<CLHEP::Hep3Vector, M>&
+    auto InitialStatePolarization() const -> const std::array<Vector3D, M>&
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
     /// @brief Set polarization vector
     /// @param pol Polarization vector (|pol| ≤ 1)
     /// @note This overload is only enabled for polarized decay
     /// @warning The Markov chain requires reinitialize if value changes
-    auto InitialStatePolarization(CLHEP::Hep3Vector pol) -> void
+    auto InitialStatePolarization(Vector3D pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
     /// @brief Set polarization for single initial particle
     /// @param i Particle index (0 ≤ i < M)
     /// @param pol Polarization vector (|pol| ≤ 1)
     /// @note This overload is only enabled for polarized scattering
     /// @warning The Markov chain requires reinitialize if value changes
-    auto InitialStatePolarization(int i, CLHEP::Hep3Vector pol) -> void
+    auto InitialStatePolarization(int i, Vector3D pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
     /// @brief Set all polarization vectors
     /// @param pol Array of polarization vectors for each initial particle (all |pol| ≤ 1)
     /// @note This overload is only enabled for polarized scattering
     /// @warning The Markov chain requires reinitialize if value changes
-    auto InitialStatePolarization(const std::array<CLHEP::Hep3Vector, M>& pol) -> void
+    auto InitialStatePolarization(const std::array<Vector3D, M>& pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
     /// @brief Set user-defined acceptance function in PDF (PDF = |M|² × acceptance)
@@ -250,12 +250,12 @@ private:
     virtual auto NextEvent(CLHEP::HepRandomEngine& rng) -> bool = 0;
 
 protected:
-    double fThinningRatio;                       ///< User-defined thinning ratio
-    unsigned fACFSampleSize;                     ///< Sample size for estimating ACF
-                                                 //
-    bool fMCMCInitialized;                       ///< Initialization completed flag
-    unsigned fThinningSize;                      ///< Samples discarded between two generated
-    MarkovChain fMC;                             ///< Current Markov chain state
+    double fThinningRatio;   ///< User-defined thinning ratio
+    unsigned fACFSampleSize; ///< Sample size for estimating ACF
+                             //
+    bool fMCMCInitialized;   ///< Initialization completed flag
+    unsigned fThinningSize;  ///< Samples discarded between two generated
+    MarkovChain fMC;         ///< Current Markov chain state
 
     static constexpr auto fgDefaultInvalidACFSampleSize{static_cast<decltype(fACFSampleSize)>(-1)};
 };

--- a/src/Mustard/Physics/Generator/MCMCGenerator.inl
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.inl
@@ -36,7 +36,7 @@ MCMCGenerator<M, N, A>::MCMCGenerator(const InitialStateMomenta& pI, const std::
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-MCMCGenerator<M, N, A>::MCMCGenerator(const InitialStateMomenta& pI, CLHEP::Hep3Vector polarization,
+MCMCGenerator<M, N, A>::MCMCGenerator(const InitialStateMomenta& pI, Vector3D polarization,
                                       const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                       std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize) // clang-format off
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> : // clang-format on
@@ -45,7 +45,7 @@ MCMCGenerator<M, N, A>::MCMCGenerator(const InitialStateMomenta& pI, CLHEP::Hep3
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-MCMCGenerator<M, N, A>::MCMCGenerator(const InitialStateMomenta& pI, const std::array<CLHEP::Hep3Vector, M>& polarization,
+MCMCGenerator<M, N, A>::MCMCGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
                                       const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                       std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize) // clang-format off
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) : // clang-format on
@@ -54,25 +54,25 @@ MCMCGenerator<M, N, A>::MCMCGenerator(const InitialStateMomenta& pI, const std::
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::InitialStatePolarization() const -> CLHEP::Hep3Vector
+auto MCMCGenerator<M, N, A>::InitialStatePolarization() const -> Vector3D
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
     return Base::InitialStatePolarization();
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::InitialStatePolarization(int i) const -> CLHEP::Hep3Vector
+auto MCMCGenerator<M, N, A>::InitialStatePolarization(int i) const -> Vector3D
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
     return Base::InitialStatePolarization(i);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::InitialStatePolarization() const -> const std::array<CLHEP::Hep3Vector, M>&
+auto MCMCGenerator<M, N, A>::InitialStatePolarization() const -> const std::array<Vector3D, M>&
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
     return Base::InitialStatePolarization();
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::InitialStatePolarization(CLHEP::Hep3Vector pol) -> void
+auto MCMCGenerator<M, N, A>::InitialStatePolarization(Vector3D pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
     if (not pol.isNear(InitialStatePolarization(), muc::default_rel_tol<double>)) {
         MCMCInitializeRequired();
@@ -81,7 +81,7 @@ auto MCMCGenerator<M, N, A>::InitialStatePolarization(CLHEP::Hep3Vector pol) -> 
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::InitialStatePolarization(int i, CLHEP::Hep3Vector pol) -> void
+auto MCMCGenerator<M, N, A>::InitialStatePolarization(int i, Vector3D pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
     if (not pol.isNear(InitialStatePolarization(i), muc::default_rel_tol<double>)) {
         MCMCInitializeRequired();
@@ -90,7 +90,7 @@ auto MCMCGenerator<M, N, A>::InitialStatePolarization(int i, CLHEP::Hep3Vector p
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::InitialStatePolarization(const std::array<CLHEP::Hep3Vector, M>& pol) -> void
+auto MCMCGenerator<M, N, A>::InitialStatePolarization(const std::array<Vector3D, M>& pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
     if (not std::ranges::equal(pol, InitialStatePolarization(),
                                [](auto&& a, auto&& b) { return a.isNear(b, muc::default_rel_tol<double>); })) {

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
@@ -22,6 +22,7 @@
 #include "Mustard/IO/PrettyLog.h++"
 #include "Mustard/Math/Estimate.h++"
 #include "Mustard/Math/MCIntegrationUtility.h++"
+#include "Mustard/Math/Vector.h++"
 #include "Mustard/Parallel/ReseedRandomEngine.h++"
 #include "Mustard/Physics/Generator/EventGenerator.h++"
 #include "Mustard/Physics/Generator/GENBOD.h++"
@@ -30,7 +31,6 @@
 #include "Mustard/Utility/VectorArithmeticOperator.h++"
 
 #include "CLHEP/Random/Random.h"
-#include "CLHEP/Vector/ThreeVector.h"
 
 #include "mplr/mplr.hpp"
 
@@ -91,7 +91,7 @@ public:
     /// @param polarization Initial-state polarization vector
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
-    MatrixElementBasedGenerator(const InitialStateMomenta& pI, CLHEP::Hep3Vector polarization,
+    MatrixElementBasedGenerator(const InitialStateMomenta& pI, Vector3D polarization,
                                 const std::array<int, N>& pdgID, const std::array<double, N>& mass)
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
     /// @brief Construct event generator
@@ -100,7 +100,7 @@ public:
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
     /// @note This overload is only enabled for polarized scattering
-    MatrixElementBasedGenerator(const InitialStateMomenta& pI, const std::array<CLHEP::Hep3Vector, M>& polarization,
+    MatrixElementBasedGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
                                 const std::array<int, N>& pdgID, const std::array<double, N>& mass)
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
@@ -117,8 +117,8 @@ public:
     ///         (2) Effective sample size
     ///         (3) Current integration state
     auto PhaseSpaceIntegral(Executor<unsigned long long>& executor, double precisionGoal,
-                            Math::MCIntegrationState integrationState = {},
-                            CLHEP::HepRandomEngine& rng = *CLHEP::HepRandom::getTheEngine()) -> std::tuple<Math::Estimate, double, Math::MCIntegrationState>;
+                            MCIntegrationState integrationState = {},
+                            CLHEP::HepRandomEngine& rng = *CLHEP::HepRandom::getTheEngine()) -> std::tuple<Estimate, double, MCIntegrationState>;
 
 protected:
     /// @brief Set initial-state 4-momenta
@@ -139,33 +139,33 @@ protected:
 
     /// @brief Get polarization vector
     /// @note This overload is only enabled for polarized decay
-    auto InitialStatePolarization() const -> CLHEP::Hep3Vector
+    auto InitialStatePolarization() const -> Vector3D
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
     /// @brief Get polarization vector
     /// @param i Particle index (0 ≤ i < M)
     /// @note This overload is only enabled for polarized scattering
-    auto InitialStatePolarization(int i) const -> CLHEP::Hep3Vector
+    auto InitialStatePolarization(int i) const -> Vector3D
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
     /// @brief Get all polarization vectors
     /// @note This overload is only enabled for polarized scattering
-    auto InitialStatePolarization() const -> const std::array<CLHEP::Hep3Vector, M>&
+    auto InitialStatePolarization() const -> const std::array<Vector3D, M>&
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
     /// @brief Set polarization vector
     /// @param pol Polarization vector (|pol| ≤ 1)
     /// @note This overload is only enabled for polarized decay
-    auto InitialStatePolarization(CLHEP::Hep3Vector pol) -> void
+    auto InitialStatePolarization(Vector3D pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
     /// @brief Set polarization for single initial particle
     /// @param i Particle index (0 ≤ i < M)
     /// @param pol Polarization vector (|pol| ≤ 1)
     /// @note This overload is only enabled for polarized scattering
-    auto InitialStatePolarization(int i, CLHEP::Hep3Vector pol) -> void
+    auto InitialStatePolarization(int i, Vector3D pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
     /// @brief Set all polarization vectors
     /// @param pol Array of polarization vectors for each initial particle (all |pol| ≤ 1)
     /// @note This overload is only enabled for polarized scattering
-    auto InitialStatePolarization(const std::array<CLHEP::Hep3Vector, M>& pol) -> void
+    auto InitialStatePolarization(const std::array<Vector3D, M>& pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
     /// @brief Add an identical particle index set
@@ -208,7 +208,7 @@ protected:
 private:
     /// @brief Monte Carlo integration implementation
     auto Integrate(std::regular_invocable<const Event&> auto&& Integrand, double precisionGoal,
-                   Math::MCIntegrationState& state, Executor<unsigned long long>& executor, CLHEP::HepRandomEngine& rng) -> std::pair<Math::Estimate, double>;
+                   MCIntegrationState& state, Executor<unsigned long long>& executor, CLHEP::HepRandomEngine& rng) -> std::pair<Estimate, double>;
 
 protected:
     [[no_unique_address]] A fMatrixElement; ///< Matrix element
@@ -216,7 +216,7 @@ protected:
 
 private:
     InitialStateMomenta fISMomenta;              ///< Initial-state 4-momenta
-    CLHEP::Hep3Vector fBoostFromLabToCM;         ///< Boost from lab frame to c.m. frame
+    Vector3D fBoostFromLabToCM;                  ///< Boost from lab frame to c.m. frame
     double fFSSymmetryFactor;                    ///< Final-state identical particle symmetry factor
     std::vector<std::vector<int>> fIdenticalSet; ///< Identical particle sets
     std::vector<std::pair<int, double>> fIRCut;  ///< IR cuts (kinetic energies)

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
@@ -35,7 +35,7 @@ MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialS
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialStateMomenta& pI, CLHEP::Hep3Vector polarization,
+MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialStateMomenta& pI, Vector3D polarization,
                                                                   const std::array<int, N>& pdgID, const std::array<double, N>& mass) // clang-format off
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> : // clang-format on
     MatrixElementBasedGenerator{pI, pdgID, mass} {
@@ -43,7 +43,7 @@ MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialS
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialStateMomenta& pI, const std::array<CLHEP::Hep3Vector, M>& polarization,
+MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
                                                                   const std::array<int, N>& pdgID, const std::array<double, N>& mass) // clang-format off
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) : // clang-format on
     MatrixElementBasedGenerator{pI, pdgID, mass} {
@@ -52,8 +52,8 @@ MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialS
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MatrixElementBasedGenerator<M, N, A>::PhaseSpaceIntegral(Executor<unsigned long long>& executor, double precisionGoal,
-                                                              Math::MCIntegrationState integrationState,
-                                                              CLHEP::HepRandomEngine& rng) -> std::tuple<Math::Estimate, double, Math::MCIntegrationState> {
+                                                              MCIntegrationState integrationState,
+                                                              CLHEP::HepRandomEngine& rng) -> std::tuple<Estimate, double, MCIntegrationState> {
     MasterPrint("Integrate |M|^2 x (Acceptance) on phase space in {}.\n"
                 "\n",
                 muc::try_demangle(typeid(*this).name()));
@@ -103,37 +103,37 @@ auto MatrixElementBasedGenerator<M, N, A>::ISMomenta(const InitialStateMomenta& 
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization() const -> CLHEP::Hep3Vector
+auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization() const -> Vector3D
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
     return fMatrixElement.InitialStatePolarization();
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization(int i) const -> CLHEP::Hep3Vector
+auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization(int i) const -> Vector3D
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
     return fMatrixElement.InitialStatePolarization(i);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization() const -> const std::array<CLHEP::Hep3Vector, M>&
+auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization() const -> const std::array<Vector3D, M>&
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
     return fMatrixElement.InitialStatePolarization();
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization(CLHEP::Hep3Vector pol) -> void
+auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization(Vector3D pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
     fMatrixElement.InitialStatePolarization(pol);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization(int i, CLHEP::Hep3Vector pol) -> void
+auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization(int i, Vector3D pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
     fMatrixElement.InitialStatePolarization(i, pol);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization(const std::array<CLHEP::Hep3Vector, M>& pol) -> void
+auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization(const std::array<Vector3D, M>& pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
     fMatrixElement.InitialStatePolarization(pol);
 }
@@ -259,7 +259,7 @@ auto MatrixElementBasedGenerator<M, N, A>::ValidMSqAcceptanceDetJ(const FinalSta
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MatrixElementBasedGenerator<M, N, A>::Integrate(std::regular_invocable<const Event&> auto&& Integrand, double precisionGoal,
-                                                     Math::MCIntegrationState& state, Executor<unsigned long long>& executor, CLHEP::HepRandomEngine& rng) -> std::pair<Math::Estimate, double> {
+                                                     MCIntegrationState& state, Executor<unsigned long long>& executor, CLHEP::HepRandomEngine& rng) -> std::pair<Estimate, double> {
     if (precisionGoal <= 0) [[unlikely]] {
         Mustard::PrintWarning(fmt::format("Non-positive precision goal (got {}), taking its absolute value", precisionGoal));
         precisionGoal = std::abs(precisionGoal);
@@ -288,7 +288,7 @@ auto MatrixElementBasedGenerator<M, N, A>::Integrate(std::regular_invocable<cons
         }
         state.sum += sum;
         state.n += nSample;
-        Math::Estimate integral;
+        Estimate integral;
         integral.value = state.sum[0] / state.n;
         integral.uncertainty = std::sqrt((state.sum[1] / state.n - muc::pow(integral.value, 2)) / state.n);
         const auto nEff{muc::pow(state.sum[0], 2) / state.sum[1]};

--- a/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.h++
+++ b/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.h++
@@ -88,7 +88,7 @@ public:
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     /// @note This overload is only enabled for polarized decay
-    MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, CLHEP::Hep3Vector polarization,
+    MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, Vector3D polarization,
                                    const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                    std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {},
                                    std::optional<double> stepSize = {})
@@ -102,7 +102,7 @@ public:
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     /// @note This overload is only enabled for polarized scattering
-    MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, const std::array<CLHEP::Hep3Vector, M>& polarization,
+    MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
                                    const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                    std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {},
                                    std::optional<double> stepSize = {})
@@ -125,8 +125,8 @@ private:
     virtual auto NextEvent(CLHEP::HepRandomEngine& rng) -> bool override;
 
 private:
-    Math::Random::Gaussian<double> fGaussian; ///< Gaussian distribution
-    double fStepSize;                         ///< Step scale along one direction in random state space
+    Random::Gaussian<double> fGaussian; ///< Gaussian distribution
+    double fStepSize;                   ///< Step scale along one direction in random state space
 
     static constexpr auto fgNTrial{5};                                            ///< Number of trial points
     static inline const auto fgScalingFactor{3.12 / std::sqrt(MarkovChain::dim)}; ///< Step size scaling factor. Ref: of M. B´edard et al. SPA 122 (2012) 758–786, https://doi.org/10.1016/j.spa.2011.11.004

--- a/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.inl
+++ b/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.inl
@@ -31,7 +31,7 @@ MultipleTryMetropolisGenerator<M, N, A>::MultipleTryMetropolisGenerator(const In
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-MultipleTryMetropolisGenerator<M, N, A>::MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, CLHEP::Hep3Vector polarization,
+MultipleTryMetropolisGenerator<M, N, A>::MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, Vector3D polarization,
                                                                         const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                                                         std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize,
                                                                         std::optional<double> stepSize) // clang-format off
@@ -45,7 +45,7 @@ MultipleTryMetropolisGenerator<M, N, A>::MultipleTryMetropolisGenerator(const In
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-MultipleTryMetropolisGenerator<M, N, A>::MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, const std::array<CLHEP::Hep3Vector, M>& polarization,
+MultipleTryMetropolisGenerator<M, N, A>::MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
                                                                         const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                                                         std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize,
                                                                         std::optional<double> stepSize) // clang-format off

--- a/src/Mustard/Physics/Generator/RAMBO.h++
+++ b/src/Mustard/Physics/Generator/RAMBO.h++
@@ -19,11 +19,11 @@
 #pragma once
 
 #include "Mustard/IO/PrettyLog.h++"
+#include "Mustard/Math/Vector.h++"
 #include "Mustard/Physics/Generator/VersatileEventGenerator.h++"
 #include "Mustard/Utility/FunctionAttribute.h++"
 
 #include "CLHEP/Units/SystemOfUnits.h"
-#include "CLHEP/Vector/LorentzVector.h"
 
 #include "muc/math"
 #include "muc/numeric"

--- a/src/Mustard/Physics/Generator/RAMBO.inl
+++ b/src/Mustard/Physics/Generator/RAMBO.inl
@@ -76,7 +76,7 @@ auto RAMBO<M, N>::operator()(const RandomState& u, InitialStateMomenta pI) -> Ev
     const auto Result{[&] {
         Event event{.weight = std::exp(wt), .pdgID = this->fPDGID, .p = {}};
         std::ranges::transform(p, event.p.begin(), [](auto&& p) {
-            return CLHEP::HepLorentzVector{p[1], p[2], p[3], p[0]};
+            return VectorLor{p[1], p[2], p[3], p[0]};
         });
         this->BoostToLabFrame(beta, event.p);
         return event;

--- a/src/Mustard/Physics/QFT/MSqM2ENNEE.c++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNEE.c++
@@ -16,11 +16,10 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
+#include "Mustard/Math/Vector.h++"
 #include "Mustard/Physics/QFT/MSqM2ENNEE.h++"
 #include "Mustard/Utility/MathConstant.h++"
 #include "Mustard/Utility/PhysicalConstant.h++"
-
-#include "CLHEP/Vector/LorentzVector.h"
 
 #include "muc/math"
 
@@ -63,7 +62,7 @@ auto MSqM2ENNEE::MSqMcMule0Av(const InitialStateMomenta& pI, const FinalStateMom
     const auto m12{p1.m2()};
     const auto m32{p3.m2()};
 
-    const auto polarized{InitialStatePolarization() != CLHEP::Hep3Vector{}};
+    const auto polarized{InitialStatePolarization() != Vector3D{}};
     const auto sqrtM12{polarized ? std::sqrt(m12) : 0};
 
     double pm2enneeav{};
@@ -77,7 +76,7 @@ auto MSqM2ENNEE::MSqMcMule0Av(const InitialStateMomenta& pI, const FinalStateMom
         pm2enneeav += 2 * OneBorn(s12, s13, s14, s23, s24, s34, m12, m22, m32) +
                       TwoBorn(s12, s13, s14, s23, s24, s34, m12, m22, m32);
         if (polarized) {
-            const CLHEP::HepLorentzVector n{-InitialStatePolarization()};
+            const VectorLor n{-InitialStatePolarization()};
             const auto s2n{s(p2, n)};
             const auto s3n{s(p3, n)};
             const auto s4n{s(p4, n)};
@@ -2870,7 +2869,7 @@ MUSTARD_OPTIMIZE_FAST auto MSqM2ENNEE::TwoBornPol(double s12, double s13, double
 MUSTARD_OPTIMIZE_FAST auto MSqM2ENNEE::MSqMcMuleLegacy(const InitialStateMomenta& pI, const FinalStateMomenta& pF) const -> double {
     const auto& q1{pI};
     const auto& [q2, q3, q4, q6, q5]{pF}; // should 5 <-> 6 for this version
-    const CLHEP::HepLorentzVector pol1{InitialStatePolarization()};
+    const VectorLor pol1{InitialStatePolarization()};
 
     // Adapt from McMule v0.5.1, mudecrare/mudecrare_pm2ennee.f95, FUNCTION PM2ENNEE
     //

--- a/src/Mustard/Physics/QFT/MSqM2ENNGG.c++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNGG.c++
@@ -16,11 +16,10 @@
 // You should have received a copy of the GNU General Public License along with
 // Mustard. If not, see <https://www.gnu.org/licenses/>.
 
+#include "Mustard/Math/Vector.h++"
 #include "Mustard/Physics/QFT/MSqM2ENNGG.h++"
 #include "Mustard/Utility/MathConstant.h++"
 #include "Mustard/Utility/PhysicalConstant.h++"
-
-#include "CLHEP/Vector/LorentzVector.h"
 
 #include "muc/math"
 
@@ -62,8 +61,8 @@ auto MSqM2ENNGG::operator()(const InitialStateMomenta& pI, const FinalStateMomen
 
     auto pm2ennggav{Unpolarized(mm2, me2, s12, s15, s16, s25, s26, s56,
                                 den1, den2, den3, den4, den5, den6)};
-    if (InitialStatePolarization() != CLHEP::Hep3Vector{}) {
-        const CLHEP::HepLorentzVector pol1{InitialStatePolarization()};
+    if (InitialStatePolarization() != Vector3D{}) {
+        const VectorLor pol1{InitialStatePolarization()};
         pm2ennggav += s(pol1, p2) * PolarizedS2n(mm2, me2, s12, s15, s16, s25, s26, s56,
                                                  den1, den2, den3, den4, den5, den6);
         pm2ennggav += s(pol1, p5) * PolarizedS5n(mm2, me2, s12, s15, s16, s25, s26, s56,

--- a/src/Mustard/Physics/QFT/MatrixElement.h++
+++ b/src/Mustard/Physics/QFT/MatrixElement.h++
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "CLHEP/Vector/LorentzVector.h"
+#include "Mustard/Math/Vector.h++"
 
 #include <array>
 #include <type_traits>
@@ -37,10 +37,9 @@ template<int M, int N>
 class MatrixElement {
 public:
     /// @brief Initial state momentum(a) type
-    using InitialStateMomenta = std::conditional_t<M == 1, CLHEP::HepLorentzVector,
-                                                   std::array<CLHEP::HepLorentzVector, M>>;
+    using InitialStateMomenta = std::conditional_t<M == 1, VectorLor, std::array<VectorLor, M>>;
     /// @brief Final state momenta type
-    using FinalStateMomenta = std::array<CLHEP::HepLorentzVector, N>;
+    using FinalStateMomenta = std::array<VectorLor, N>;
 
 public:
     virtual ~MatrixElement() = default;

--- a/src/Mustard/Physics/QFT/PolarizedMatrixElement.h++
+++ b/src/Mustard/Physics/QFT/PolarizedMatrixElement.h++
@@ -19,9 +19,8 @@
 #pragma once
 
 #include "Mustard/IO/PrettyLog.h++"
+#include "Mustard/Math/Vector.h++"
 #include "Mustard/Physics/QFT/MatrixElement.h++"
-
-#include "CLHEP/Vector/ThreeVector.h"
 
 #include "fmt/core.h"
 
@@ -44,7 +43,7 @@ public:
     PolarizedMatrixElement() = default;
     /// @brief Construct with initial polarization array
     /// @param pol Array of polarization vectors for each initial particle (all |p| ≤ 1)
-    PolarizedMatrixElement(const std::array<CLHEP::Hep3Vector, M>& pol);
+    PolarizedMatrixElement(const std::array<Vector3D, M>& pol);
 
     /// @brief Get polarization vector for single initial particle
     /// @param i Particle index (0 ≤ i < M)
@@ -55,13 +54,13 @@ public:
     /// @brief Set polarization for single initial particle
     /// @param i Particle index (0 ≤ i < M)
     /// @param pol Polarization vector (|p| ≤ 1)
-    auto InitialStatePolarization(int i, CLHEP::Hep3Vector pol) -> void;
+    auto InitialStatePolarization(int i, Vector3D pol) -> void;
     /// @brief Set all polarization vectors
     /// @param pol Array of polarization vectors for each initial particle (all |p| ≤ 1)
-    auto InitialStatePolarization(const std::array<CLHEP::Hep3Vector, M>& pol) -> void;
+    auto InitialStatePolarization(const std::array<Vector3D, M>& pol) -> void;
 
 private:
-    std::array<CLHEP::Hep3Vector, M> fInitialStatePolarization; ///< Polarization storage
+    std::array<Vector3D, M> fInitialStatePolarization; ///< Polarization storage
 };
 
 /// @class PolarizedMatrixElement<1, N>
@@ -77,16 +76,16 @@ public:
     PolarizedMatrixElement() = default;
     /// @brief Construct with polarization vector
     /// @param pol Polarization vector (|p| ≤ 1)
-    PolarizedMatrixElement(CLHEP::Hep3Vector pol);
+    PolarizedMatrixElement(Vector3D pol);
 
     /// @brief Get polarization vector
     auto InitialStatePolarization() const -> auto { return fInitialStatePolarization; }
     /// @brief Set polarization vector
     /// @param pol Polarization vector (|p| ≤ 1)
-    auto InitialStatePolarization(CLHEP::Hep3Vector pol) -> void;
+    auto InitialStatePolarization(Vector3D pol) -> void;
 
 private:
-    CLHEP::Hep3Vector fInitialStatePolarization;
+    Vector3D fInitialStatePolarization;
 };
 
 } // namespace Mustard::inline Physics::QFT

--- a/src/Mustard/Physics/QFT/PolarizedMatrixElement.inl
+++ b/src/Mustard/Physics/QFT/PolarizedMatrixElement.inl
@@ -19,13 +19,13 @@
 namespace Mustard::inline Physics::QFT {
 
 template<int M, int N>
-PolarizedMatrixElement<M, N>::PolarizedMatrixElement(const std::array<CLHEP::Hep3Vector, M>& pol) :
+PolarizedMatrixElement<M, N>::PolarizedMatrixElement(const std::array<Vector3D, M>& pol) :
     PolarizedMatrixElement{} {
     InitialStatePolarization(pol);
 }
 
 template<int M, int N>
-auto PolarizedMatrixElement<M, N>::InitialStatePolarization(int i, CLHEP::Hep3Vector pol) -> void {
+auto PolarizedMatrixElement<M, N>::InitialStatePolarization(int i, Vector3D pol) -> void {
     const auto polNorm{pol.mag()};
     if (polNorm > 1) [[unlikely]] {
         PrintWarning(fmt::format("Got polarization {} (pol) with |pol| = {} (expects |pol| <= 1)", i, polNorm));
@@ -34,20 +34,20 @@ auto PolarizedMatrixElement<M, N>::InitialStatePolarization(int i, CLHEP::Hep3Ve
 }
 
 template<int M, int N>
-auto PolarizedMatrixElement<M, N>::InitialStatePolarization(const std::array<CLHEP::Hep3Vector, M>& pol) -> void {
+auto PolarizedMatrixElement<M, N>::InitialStatePolarization(const std::array<Vector3D, M>& pol) -> void {
     for (int i{}; i < M; ++i) {
         InitialStatePolarization(i, pol[i]);
     }
 }
 
 template<int N>
-PolarizedMatrixElement<1, N>::PolarizedMatrixElement(CLHEP::Hep3Vector pol) :
+PolarizedMatrixElement<1, N>::PolarizedMatrixElement(Vector3D pol) :
     PolarizedMatrixElement{} {
     InitialStatePolarization(pol);
 }
 
 template<int N>
-auto PolarizedMatrixElement<1, N>::InitialStatePolarization(CLHEP::Hep3Vector pol) -> void {
+auto PolarizedMatrixElement<1, N>::InitialStatePolarization(Vector3D pol) -> void {
     const auto polNorm{pol.mag()};
     if (polNorm > 1) [[unlikely]] {
         PrintWarning(fmt::format("Got polarization (pol) with |pol| = {} (expects |pol| <= 1)", polNorm));

--- a/src/Mustard/ROOTX/Math/AsTRandom.h++
+++ b/src/Mustard/ROOTX/Math/AsTRandom.h++
@@ -37,12 +37,12 @@ namespace Mustard::ROOTX::Math {
 /// including Gaussian generation and bulk array generation.
 ///
 /// @tparam PRBG Mustard UniformPseudoRandomBitGenerator type to adapt
-///   - Must satisfy Mustard::Math::Random::UniformPseudoRandomBitGenerator
+///   - Must satisfy Mustard::Random::UniformPseudoRandomBitGenerator
 ///   - Must provide SeedType and Seed() method
 ///
 /// @note Inherits from ROOT's TRandom for full framework integration
 /// @warning GetSeed() is intentionally non-functional (ROOT API limitation)
-template<Mustard::Math::Random::UniformPseudoRandomBitGenerator PRBG>
+template<Mustard::Random::UniformPseudoRandomBitGenerator PRBG>
 class AsTRandom : public TRandom {
 public:
     /// @brief Default constructor (uses PRBG's default seed)
@@ -62,7 +62,7 @@ public:
     /// @param seed New seed value (converted to PRBG's SeedType)
     virtual auto SetSeed(ULong_t seed) -> void override { fPRBG.Seed(seed); }
     /// @brief Generate uniform double in (0,1)
-    virtual auto Rndm() -> Double_t override { return Mustard::Math::Random::Uniform<Double_t>{}(fPRBG); }
+    virtual auto Rndm() -> Double_t override { return Mustard::Random::Uniform<Double_t>{}(fPRBG); }
     /// @brief Fill array with uniform float values in (0,1)
     /// @param n Number of elements to generate
     /// @param array Pre-allocated output buffer
@@ -80,7 +80,7 @@ private:
 
 private:
     PRBG fPRBG;
-    Mustard::Math::Random::Gaussian<Double_t> fGaussian;
+    Mustard::Random::Gaussian<Double_t> fGaussian;
 };
 
 } // namespace Mustard::ROOTX::Math

--- a/src/Mustard/ROOTX/Math/AsTRandom.inl
+++ b/src/Mustard/ROOTX/Math/AsTRandom.inl
@@ -18,22 +18,22 @@
 
 namespace Mustard::ROOTX::Math {
 
-template<Mustard::Math::Random::UniformPseudoRandomBitGenerator PRBG>
+template<Mustard::Random::UniformPseudoRandomBitGenerator PRBG>
 AsTRandom<PRBG>::AsTRandom(typename PRBG::SeedType seed) :
     fPRBG{seed},
     fGaussian{} {}
 
-template<Mustard::Math::Random::UniformPseudoRandomBitGenerator PRBG>
+template<Mustard::Random::UniformPseudoRandomBitGenerator PRBG>
 auto AsTRandom<PRBG>::RndmArray(Int_t n, Float_t* array) -> void {
-    std::ranges::generate_n(array, n, [this] { return Mustard::Math::Random::Uniform<Float_t>{}(fPRBG); });
+    std::ranges::generate_n(array, n, [this] { return Mustard::Random::Uniform<Float_t>{}(fPRBG); });
 }
 
-template<Mustard::Math::Random::UniformPseudoRandomBitGenerator PRBG>
+template<Mustard::Random::UniformPseudoRandomBitGenerator PRBG>
 auto AsTRandom<PRBG>::RndmArray(Int_t n, Double_t* array) -> void {
     std::ranges::generate_n(array, n, [this] { return Rndm(); });
 }
 
-template<Mustard::Math::Random::UniformPseudoRandomBitGenerator PRBG>
+template<Mustard::Random::UniformPseudoRandomBitGenerator PRBG>
 auto AsTRandom<PRBG>::GetSeed() const -> UInt_t {
     PrintError("AsTRandom<PRBG>::GetSeed has no effect. Do not use");
     return 0;

--- a/src/Mustard/ROOTX/Math/AsTRandomEngine.h++
+++ b/src/Mustard/ROOTX/Math/AsTRandomEngine.h++
@@ -54,7 +54,7 @@ public:
 
     /// @brief Generate uniform double in [0,1) (ROOT interface requirement)
     /// @return Random double value in unit interval
-    auto Rndm() -> double override { Mustard::Random::Uniform<double>{}(fPRBG); }
+    auto Rndm() -> double override { return Mustard::Random::Uniform<double>{}(fPRBG); }
 
     /// @brief Functor interface equivalent to Rndm()
     auto operator()() -> auto { return Rndm(); }

--- a/src/Mustard/ROOTX/Math/AsTRandomEngine.h++
+++ b/src/Mustard/ROOTX/Math/AsTRandomEngine.h++
@@ -36,11 +36,11 @@ namespace Mustard::ROOTX::Math {
 /// with ROOT's statistical functions and classes.
 ///
 /// @tparam PRBG Mustard UniformPseudoRandomBitGenerator type to adapt
-///   - Must satisfy Mustard::Math::Random::UniformPseudoRandomBitGenerator concept
+///   - Must satisfy Mustard::Random::UniformPseudoRandomBitGenerator concept
 ///   - Must provide SeedType, Seed(), Min(), Max(), and operator()
 ///
 /// @note Inherits from ROOT::Math::TRandomEngine to integrate with ROOT framework
-template<Mustard::Math::Random::UniformPseudoRandomBitGenerator PRBG>
+template<Mustard::Random::UniformPseudoRandomBitGenerator PRBG>
 class AsTRandomEngine : public ROOT::Math::TRandomEngine {
 public:
     /// @brief Default constructor (uses PRBG's default seed)
@@ -54,7 +54,7 @@ public:
 
     /// @brief Generate uniform double in [0,1) (ROOT interface requirement)
     /// @return Random double value in unit interval
-    auto Rndm() -> double override { Mustard::Math::Random::Uniform<double>{}(fPRBG); }
+    auto Rndm() -> double override { Mustard::Random::Uniform<double>{}(fPRBG); }
 
     /// @brief Functor interface equivalent to Rndm()
     auto operator()() -> auto { return Rndm(); }

--- a/src/Mustard/ROOTX/Math/AsTRandomEngine.inl
+++ b/src/Mustard/ROOTX/Math/AsTRandomEngine.inl
@@ -18,7 +18,7 @@
 
 namespace Mustard::ROOTX::Math {
 
-template<Mustard::Math::Random::UniformPseudoRandomBitGenerator PRBG>
+template<Mustard::Random::UniformPseudoRandomBitGenerator PRBG>
 AsTRandomEngine<PRBG>::AsTRandomEngine(typename PRBG::SeedType seed) :
     fPRBG{seed} {}
 

--- a/src/Mustard/ROOTX/Math/Xoshiro.h++
+++ b/src/Mustard/ROOTX/Math/Xoshiro.h++
@@ -18,21 +18,21 @@
 
 #pragma once
 
-#include "Mustard/Math/Random/Generator/Xoshiro256PlusPlus.h++"
 #include "Mustard/Math/Random/Generator/Xoshiro256Plus.h++"
+#include "Mustard/Math/Random/Generator/Xoshiro256PlusPlus.h++"
 #include "Mustard/Math/Random/Generator/Xoshiro256StarStar.h++"
-#include "Mustard/Math/Random/Generator/Xoshiro512PlusPlus.h++"
 #include "Mustard/Math/Random/Generator/Xoshiro512Plus.h++"
+#include "Mustard/Math/Random/Generator/Xoshiro512PlusPlus.h++"
 #include "Mustard/Math/Random/Generator/Xoshiro512StarStar.h++"
 #include "Mustard/ROOTX/Math/AsTRandom.h++"
 
 namespace Mustard::ROOTX::Math {
 
-using Xoshiro256StarStar = ROOTX::Math::AsTRandom<Mustard::Math::Random::Xoshiro256StarStar>;
-using Xoshiro256PlusPlus = ROOTX::Math::AsTRandom<Mustard::Math::Random::Xoshiro256PlusPlus>;
-using Xoshiro256Plus = ROOTX::Math::AsTRandom<Mustard::Math::Random::Xoshiro256Plus>;
-using Xoshiro512StarStar = ROOTX::Math::AsTRandom<Mustard::Math::Random::Xoshiro512StarStar>;
-using Xoshiro512PlusPlus = ROOTX::Math::AsTRandom<Mustard::Math::Random::Xoshiro512PlusPlus>;
-using Xoshiro512Plus = ROOTX::Math::AsTRandom<Mustard::Math::Random::Xoshiro512Plus>;
+using Xoshiro256StarStar = ROOTX::Math::AsTRandom<Mustard::Random::Xoshiro256StarStar>;
+using Xoshiro256PlusPlus = ROOTX::Math::AsTRandom<Mustard::Random::Xoshiro256PlusPlus>;
+using Xoshiro256Plus = ROOTX::Math::AsTRandom<Mustard::Random::Xoshiro256Plus>;
+using Xoshiro512StarStar = ROOTX::Math::AsTRandom<Mustard::Random::Xoshiro512StarStar>;
+using Xoshiro512PlusPlus = ROOTX::Math::AsTRandom<Mustard::Random::Xoshiro512PlusPlus>;
+using Xoshiro512Plus = ROOTX::Math::AsTRandom<Mustard::Random::Xoshiro512Plus>;
 
 } // namespace Mustard::ROOTX::Math

--- a/test/CLHEPX/Random/MT1993732Engine.c++
+++ b/test/CLHEPX/Random/MT1993732Engine.c++
@@ -30,7 +30,7 @@
 using namespace Mustard;
 
 int main() {
-    Math::Random::MT1993732 mt32{0x123456};
+    Random::MT1993732 mt32{0x123456};
     CLHEPX::Random::MT1993732 mt32x{0x123456};
 
     std::cout << "Simply generate 10 million integers:" << std::endl;
@@ -61,14 +61,14 @@ int main() {
     Eigen::RowVector2d delta2d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt32),
-                   Math::Random::Uniform<double>()(mt32)};
+        delta2d = {Random::Uniform<double>()(mt32),
+                   Random::Uniform<double>()(mt32)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt32),
-                   Math::Random::Uniform<double>()(mt32)};
+        delta2d = {Random::Uniform<double>()(mt32),
+                   Random::Uniform<double>()(mt32)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -94,16 +94,16 @@ int main() {
     Eigen::RowVector3d delta3d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt32),
-                   Math::Random::Uniform<double>()(mt32),
-                   Math::Random::Uniform<double>()(mt32)};
+        delta3d = {Random::Uniform<double>()(mt32),
+                   Random::Uniform<double>()(mt32),
+                   Random::Uniform<double>()(mt32)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt32),
-                   Math::Random::Uniform<double>()(mt32),
-                   Math::Random::Uniform<double>()(mt32)};
+        delta3d = {Random::Uniform<double>()(mt32),
+                   Random::Uniform<double>()(mt32),
+                   Random::Uniform<double>()(mt32)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -131,18 +131,18 @@ int main() {
     Eigen::RowVector4d delta4d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt32),
-                   Math::Random::Uniform<double>()(mt32),
-                   Math::Random::Uniform<double>()(mt32),
-                   Math::Random::Uniform<double>()(mt32)};
+        delta4d = {Random::Uniform<double>()(mt32),
+                   Random::Uniform<double>()(mt32),
+                   Random::Uniform<double>()(mt32),
+                   Random::Uniform<double>()(mt32)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt32),
-                   Math::Random::Uniform<double>()(mt32),
-                   Math::Random::Uniform<double>()(mt32),
-                   Math::Random::Uniform<double>()(mt32)};
+        delta4d = {Random::Uniform<double>()(mt32),
+                   Random::Uniform<double>()(mt32),
+                   Random::Uniform<double>()(mt32),
+                   Random::Uniform<double>()(mt32)};
         v4d += delta4d;
     }
     time = stopwatch.read();

--- a/test/CLHEPX/Random/MT1993764Engine.c++
+++ b/test/CLHEPX/Random/MT1993764Engine.c++
@@ -30,7 +30,7 @@
 using namespace Mustard;
 
 int main() {
-    Math::Random::MT1993764 mt64{0x123456};
+    Random::MT1993764 mt64{0x123456};
     Mustard::CLHEPX::Random::MT1993764 mt64x{0x123456};
 
     std::cout << "Simply generate 10 million integers:" << std::endl;
@@ -61,14 +61,14 @@ int main() {
     Eigen::RowVector2d delta2d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt64),
-                   Math::Random::Uniform<double>()(mt64)};
+        delta2d = {Random::Uniform<double>()(mt64),
+                   Random::Uniform<double>()(mt64)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt64),
-                   Math::Random::Uniform<double>()(mt64)};
+        delta2d = {Random::Uniform<double>()(mt64),
+                   Random::Uniform<double>()(mt64)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -94,16 +94,16 @@ int main() {
     Eigen::RowVector3d delta3d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt64),
-                   Math::Random::Uniform<double>()(mt64),
-                   Math::Random::Uniform<double>()(mt64)};
+        delta3d = {Random::Uniform<double>()(mt64),
+                   Random::Uniform<double>()(mt64),
+                   Random::Uniform<double>()(mt64)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt64),
-                   Math::Random::Uniform<double>()(mt64),
-                   Math::Random::Uniform<double>()(mt64)};
+        delta3d = {Random::Uniform<double>()(mt64),
+                   Random::Uniform<double>()(mt64),
+                   Random::Uniform<double>()(mt64)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -131,18 +131,18 @@ int main() {
     Eigen::RowVector4d delta4d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt64),
-                   Math::Random::Uniform<double>()(mt64),
-                   Math::Random::Uniform<double>()(mt64),
-                   Math::Random::Uniform<double>()(mt64)};
+        delta4d = {Random::Uniform<double>()(mt64),
+                   Random::Uniform<double>()(mt64),
+                   Random::Uniform<double>()(mt64),
+                   Random::Uniform<double>()(mt64)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt64),
-                   Math::Random::Uniform<double>()(mt64),
-                   Math::Random::Uniform<double>()(mt64),
-                   Math::Random::Uniform<double>()(mt64)};
+        delta4d = {Random::Uniform<double>()(mt64),
+                   Random::Uniform<double>()(mt64),
+                   Random::Uniform<double>()(mt64),
+                   Random::Uniform<double>()(mt64)};
         v4d += delta4d;
     }
     time = stopwatch.read();

--- a/test/CLHEPX/Random/Xoshiro256StarStarEngine.c++
+++ b/test/CLHEPX/Random/Xoshiro256StarStarEngine.c++
@@ -30,8 +30,8 @@
 using namespace Mustard;
 
 int main() {
-    Math::Random::Xoshiro256StarStar xoshiro256SS(0x123456);
-    CLHEPX::Random::Wrap<Math::Random::Xoshiro256StarStar> xoshiro256SSX(0x123456);
+    Random::Xoshiro256StarStar xoshiro256SS(0x123456);
+    CLHEPX::Random::Wrap<Random::Xoshiro256StarStar> xoshiro256SSX(0x123456);
 
     std::cout << "Simply generate 10 million integers:" << std::endl;
 
@@ -61,14 +61,14 @@ int main() {
     Eigen::RowVector2d delta2d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS)};
+        delta2d = {Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS)};
+        delta2d = {Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -94,16 +94,16 @@ int main() {
     Eigen::RowVector3d delta3d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS)};
+        delta3d = {Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS)};
+        delta3d = {Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -131,18 +131,18 @@ int main() {
     Eigen::RowVector4d delta4d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS)};
+        delta4d = {Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS)};
+        delta4d = {Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS)};
         v4d += delta4d;
     }
     time = stopwatch.read();

--- a/test/CLHEPX/Random/Xoshiro512StarStarEngine.c++
+++ b/test/CLHEPX/Random/Xoshiro512StarStarEngine.c++
@@ -30,8 +30,8 @@
 using namespace Mustard;
 
 int main() {
-    Math::Random::Xoshiro512StarStar xoshiro512SS(0x123456);
-    CLHEPX::Random::Wrap<Math::Random::Xoshiro512StarStar> xoshiro512SSX(0x123456);
+    Random::Xoshiro512StarStar xoshiro512SS(0x123456);
+    CLHEPX::Random::Wrap<Random::Xoshiro512StarStar> xoshiro512SSX(0x123456);
 
     std::cout << "Simply generate 10 million integers:" << std::endl;
 
@@ -61,14 +61,14 @@ int main() {
     Eigen::RowVector2d delta2d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS)};
+        delta2d = {Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS)};
+        delta2d = {Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -94,16 +94,16 @@ int main() {
     Eigen::RowVector3d delta3d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS)};
+        delta3d = {Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS)};
+        delta3d = {Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -131,18 +131,18 @@ int main() {
     Eigen::RowVector4d delta4d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS)};
+        delta4d = {Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS)};
+        delta4d = {Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS)};
         v4d += delta4d;
     }
     time = stopwatch.read();

--- a/test/Concept/VectorConcept.c++
+++ b/test/Concept/VectorConcept.c++
@@ -16,10 +16,7 @@
 
 #include "Mustard/Concept/MathVector.h++"
 #include "Mustard/Concept/NumericVector.h++"
-
-#include "CLHEP/Vector/LorentzVector.h"
-#include "CLHEP/Vector/ThreeVector.h"
-#include "CLHEP/Vector/TwoVector.h"
+#include "Mustard/Math/Vector.h++"
 
 #if __has_include("TEveVector.h")
 #    include "TEveVector.h"
@@ -84,9 +81,9 @@ static_assert(MathVector<Eigen::Vector2d, double, 2>);
 static_assert(MathVector<Eigen::Vector3d, double, 3>);
 static_assert(MathVector<Eigen::Vector4d, double, 4>);
 
-static_assert(MathVector<CLHEP::Hep2Vector, double, 2>);
-static_assert(MathVector<CLHEP::Hep3Vector, double, 3>);
-static_assert(MathVector<CLHEP::HepLorentzVector, double, 4>);
+static_assert(MathVector<Mustard::Vector2D, double, 2>);
+static_assert(MathVector<Mustard::Vector3D, double, 3>);
+static_assert(MathVector<Mustard::VectorLor, double, 4>);
 
 #if __has_include("TEveVector.h")
 static_assert(not MathVector<TEveVector2D, double, 2>);

--- a/test/Math/Random/Distribution/Gaussian.c++
+++ b/test/Math/Random/Distribution/Gaussian.c++
@@ -26,7 +26,7 @@
 using namespace Mustard;
 
 int main(int argc, char* argv[]) {
-    Math::Random::MT1993764 mt1993764;
+    Random::MT1993764 mt1993764;
 
     const auto n = std::stod(argv[1]);
     const auto mu1 = argc > 2 ? std::stod(argv[2]) : 0;
@@ -39,11 +39,11 @@ int main(int argc, char* argv[]) {
     ROOT::RDataFrame dataFrame(n);
     dataFrame
         .Define("g1",
-                [&] { return Math::Random::Gaussian(mu1, sigma1)(mt1993764); })
+                [&] { return Random::Gaussian(mu1, sigma1)(mt1993764); })
         .Define("g2",
-                [&] { return Math::Random::Gaussian2DDiagnoal({mu1, sigma1}, {mu2, sigma2})(mt1993764); })
+                [&] { return Random::Gaussian2DDiagnoal({mu1, sigma1}, {mu2, sigma2})(mt1993764); })
         .Define("g3",
-                [&] { return Math::Random::Gaussian3DDiagnoal({mu1, sigma1}, {mu2, sigma2}, {mu3, sigma3})(mt1993764); })
+                [&] { return Random::Gaussian3DDiagnoal({mu1, sigma1}, {mu2, sigma2}, {mu3, sigma3})(mt1993764); })
 
         .Snapshot("gaussian", "gaussian.root");
 

--- a/test/Math/Random/Distribution/Uniform.c++
+++ b/test/Math/Random/Distribution/Uniform.c++
@@ -25,7 +25,7 @@
 using namespace Mustard;
 
 int main(int argc, char* argv[]) {
-    Math::Random::MT1993764 mt1993764;
+    Random::MT1993764 mt1993764;
 
     const auto n = std::stod(argv[1]);
     const auto a1 = argc > 2 ? std::stod(argv[2]) : 0;
@@ -38,25 +38,25 @@ int main(int argc, char* argv[]) {
     ROOT::RDataFrame dataFrame(n);
     dataFrame
         .Define("uc",
-                [&] { return Math::Random::UniformCompact<double>(a1, b1)(mt1993764); })
+                [&] { return Random::UniformCompact<double>(a1, b1)(mt1993764); })
         .Define("ur",
-                [&] { return Math::Random::Uniform<double>(a1, b1)(mt1993764); })
+                [&] { return Random::Uniform<double>(a1, b1)(mt1993764); })
         .Define("ui",
-                [&] { return Math::Random::Uniform<int>(a1, b1)(mt1993764); })
+                [&] { return Random::Uniform<int>(a1, b1)(mt1993764); })
 
         .Define("ucr",
-                [&] { return Math::Random::UniformCompactRectangle<muc::array2d>({a1, b1}, {a2, b2})(mt1993764); })
+                [&] { return Random::UniformCompactRectangle<muc::array2d>({a1, b1}, {a2, b2})(mt1993764); })
         .Define("urr",
-                [&] { return Math::Random::UniformRectangle<muc::array2d>({a1, b1}, {a2, b2})(mt1993764); })
+                [&] { return Random::UniformRectangle<muc::array2d>({a1, b1}, {a2, b2})(mt1993764); })
         .Define("uir",
-                [&] { return Math::Random::UniformRectangle<muc::array2i>({(int)a1, (int)b1}, {(int)a2, (int)b2})(mt1993764); })
+                [&] { return Random::UniformRectangle<muc::array2i>({(int)a1, (int)b1}, {(int)a2, (int)b2})(mt1993764); })
 
         // .Define("ucc",
-        //         [&] { return Math::Random::UniformCompactCuboid<muc::array3d>({a1, b1}, {a2, b2}, {a3, b3})(mt1993764); })
+        //         [&] { return Random::UniformCompactCuboid<muc::array3d>({a1, b1}, {a2, b2}, {a3, b3})(mt1993764); })
         // .Define("urc",
-        //         [&] { return Math::Random::UniformCuboid<muc::array3d>({a1, b1}, {a2, b2}, {a3, b3})(mt1993764); })
+        //         [&] { return Random::UniformCuboid<muc::array3d>({a1, b1}, {a2, b2}, {a3, b3})(mt1993764); })
         // .Define("uic",
-        //         [&] { return Math::Random::UniformCuboid<muc::array3i>({(int)a1, (int)b1}, {(int)a2, (int)b2}, {(int)a3, (int)b3})(mt1993764); })
+        //         [&] { return Random::UniformCuboid<muc::array3i>({(int)a1, (int)b1}, {(int)a2, (int)b2}, {(int)a3, (int)b3})(mt1993764); })
 
         .Snapshot("uniform", "uniform.root");
 

--- a/test/Math/Random/Generator/MT1993732.c++
+++ b/test/Math/Random/Generator/MT1993732.c++
@@ -32,7 +32,7 @@ using namespace Mustard;
 
 int main() {
     std::mt19937 stdMT1993732;
-    Math::Random::MT1993732 mt1993732;
+    Random::MT1993732 mt1993732;
 
     std::cout << "Simply generate 10 million integers:" << std::endl;
 

--- a/test/Math/Random/Generator/MT1993764.c++
+++ b/test/Math/Random/Generator/MT1993764.c++
@@ -32,7 +32,7 @@ using namespace Mustard;
 
 int main() {
     std::mt19937_64 stdMT1993764;
-    Math::Random::MT1993764 mt1993764;
+    Random::MT1993764 mt1993764;
 
     std::cout << "Simply generate 10 million integers:" << std::endl;
 

--- a/test/Math/Random/Generator/Xoshiro256Plus.c++
+++ b/test/Math/Random/Generator/Xoshiro256Plus.c++
@@ -33,8 +33,8 @@
 using namespace Mustard;
 
 int main() {
-    Math::Random::MT1993732 mt1993732;
-    Math::Random::Xoshiro256Plus xoshiro256Plus;
+    Random::MT1993732 mt1993732;
+    Random::Xoshiro256Plus xoshiro256Plus;
 
     std::cout << "Simply generate 10 million integers:" << std::endl;
 
@@ -112,14 +112,14 @@ int main() {
     Eigen::RowVector2d delta2d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta2d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta2d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -127,14 +127,14 @@ int main() {
 
     v2d = {0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro256Plus),
-                   Math::Random::Uniform<double>()(xoshiro256Plus)};
+        delta2d = {Random::Uniform<double>()(xoshiro256Plus),
+                   Random::Uniform<double>()(xoshiro256Plus)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro256Plus),
-                   Math::Random::Uniform<double>()(xoshiro256Plus)};
+        delta2d = {Random::Uniform<double>()(xoshiro256Plus),
+                   Random::Uniform<double>()(xoshiro256Plus)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -145,16 +145,16 @@ int main() {
     Eigen::RowVector3d delta3d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta3d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta3d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -162,16 +162,16 @@ int main() {
 
     v3d = {0, 0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro256Plus),
-                   Math::Random::Uniform<double>()(xoshiro256Plus),
-                   Math::Random::Uniform<double>()(xoshiro256Plus)};
+        delta3d = {Random::Uniform<double>()(xoshiro256Plus),
+                   Random::Uniform<double>()(xoshiro256Plus),
+                   Random::Uniform<double>()(xoshiro256Plus)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro256Plus),
-                   Math::Random::Uniform<double>()(xoshiro256Plus),
-                   Math::Random::Uniform<double>()(xoshiro256Plus)};
+        delta3d = {Random::Uniform<double>()(xoshiro256Plus),
+                   Random::Uniform<double>()(xoshiro256Plus),
+                   Random::Uniform<double>()(xoshiro256Plus)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -182,18 +182,18 @@ int main() {
     Eigen::RowVector4d delta4d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta4d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta4d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v4d += delta4d;
     }
     time = stopwatch.read();
@@ -201,18 +201,18 @@ int main() {
 
     v4d = {0, 0, 0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro256Plus),
-                   Math::Random::Uniform<double>()(xoshiro256Plus),
-                   Math::Random::Uniform<double>()(xoshiro256Plus),
-                   Math::Random::Uniform<double>()(xoshiro256Plus)};
+        delta4d = {Random::Uniform<double>()(xoshiro256Plus),
+                   Random::Uniform<double>()(xoshiro256Plus),
+                   Random::Uniform<double>()(xoshiro256Plus),
+                   Random::Uniform<double>()(xoshiro256Plus)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro256Plus),
-                   Math::Random::Uniform<double>()(xoshiro256Plus),
-                   Math::Random::Uniform<double>()(xoshiro256Plus),
-                   Math::Random::Uniform<double>()(xoshiro256Plus)};
+        delta4d = {Random::Uniform<double>()(xoshiro256Plus),
+                   Random::Uniform<double>()(xoshiro256Plus),
+                   Random::Uniform<double>()(xoshiro256Plus),
+                   Random::Uniform<double>()(xoshiro256Plus)};
         v4d += delta4d;
     }
     time = stopwatch.read();

--- a/test/Math/Random/Generator/Xoshiro256PlusPlus.c++
+++ b/test/Math/Random/Generator/Xoshiro256PlusPlus.c++
@@ -33,8 +33,8 @@
 using namespace Mustard;
 
 int main() {
-    Math::Random::MT1993732 mt1993732;
-    Math::Random::Xoshiro256PlusPlus xoshiro256PP;
+    Random::MT1993732 mt1993732;
+    Random::Xoshiro256PlusPlus xoshiro256PP;
 
     std::cout << "Simply generate 10 million integers:" << std::endl;
 
@@ -112,14 +112,14 @@ int main() {
     Eigen::RowVector2d delta2d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta2d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta2d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -127,14 +127,14 @@ int main() {
 
     v2d = {0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro256PP),
-                   Math::Random::Uniform<double>()(xoshiro256PP)};
+        delta2d = {Random::Uniform<double>()(xoshiro256PP),
+                   Random::Uniform<double>()(xoshiro256PP)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro256PP),
-                   Math::Random::Uniform<double>()(xoshiro256PP)};
+        delta2d = {Random::Uniform<double>()(xoshiro256PP),
+                   Random::Uniform<double>()(xoshiro256PP)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -145,16 +145,16 @@ int main() {
     Eigen::RowVector3d delta3d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta3d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta3d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -162,16 +162,16 @@ int main() {
 
     v3d = {0, 0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro256PP),
-                   Math::Random::Uniform<double>()(xoshiro256PP),
-                   Math::Random::Uniform<double>()(xoshiro256PP)};
+        delta3d = {Random::Uniform<double>()(xoshiro256PP),
+                   Random::Uniform<double>()(xoshiro256PP),
+                   Random::Uniform<double>()(xoshiro256PP)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro256PP),
-                   Math::Random::Uniform<double>()(xoshiro256PP),
-                   Math::Random::Uniform<double>()(xoshiro256PP)};
+        delta3d = {Random::Uniform<double>()(xoshiro256PP),
+                   Random::Uniform<double>()(xoshiro256PP),
+                   Random::Uniform<double>()(xoshiro256PP)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -182,18 +182,18 @@ int main() {
     Eigen::RowVector4d delta4d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta4d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta4d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v4d += delta4d;
     }
     time = stopwatch.read();
@@ -201,18 +201,18 @@ int main() {
 
     v4d = {0, 0, 0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro256PP),
-                   Math::Random::Uniform<double>()(xoshiro256PP),
-                   Math::Random::Uniform<double>()(xoshiro256PP),
-                   Math::Random::Uniform<double>()(xoshiro256PP)};
+        delta4d = {Random::Uniform<double>()(xoshiro256PP),
+                   Random::Uniform<double>()(xoshiro256PP),
+                   Random::Uniform<double>()(xoshiro256PP),
+                   Random::Uniform<double>()(xoshiro256PP)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro256PP),
-                   Math::Random::Uniform<double>()(xoshiro256PP),
-                   Math::Random::Uniform<double>()(xoshiro256PP),
-                   Math::Random::Uniform<double>()(xoshiro256PP)};
+        delta4d = {Random::Uniform<double>()(xoshiro256PP),
+                   Random::Uniform<double>()(xoshiro256PP),
+                   Random::Uniform<double>()(xoshiro256PP),
+                   Random::Uniform<double>()(xoshiro256PP)};
         v4d += delta4d;
     }
     time = stopwatch.read();

--- a/test/Math/Random/Generator/Xoshiro256StarStar.c++
+++ b/test/Math/Random/Generator/Xoshiro256StarStar.c++
@@ -33,8 +33,8 @@
 using namespace Mustard;
 
 int main() {
-    Math::Random::MT1993732 mt1993732;
-    Math::Random::Xoshiro256StarStar xoshiro256SS;
+    Random::MT1993732 mt1993732;
+    Random::Xoshiro256StarStar xoshiro256SS;
 
     std::cout << "Simply generate 10 million integers:" << std::endl;
 
@@ -112,14 +112,14 @@ int main() {
     Eigen::RowVector2d delta2d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta2d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta2d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -127,14 +127,14 @@ int main() {
 
     v2d = {0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS)};
+        delta2d = {Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS)};
+        delta2d = {Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -145,16 +145,16 @@ int main() {
     Eigen::RowVector3d delta3d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta3d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta3d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -162,16 +162,16 @@ int main() {
 
     v3d = {0, 0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS)};
+        delta3d = {Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS)};
+        delta3d = {Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -182,18 +182,18 @@ int main() {
     Eigen::RowVector4d delta4d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta4d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta4d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v4d += delta4d;
     }
     time = stopwatch.read();
@@ -201,18 +201,18 @@ int main() {
 
     v4d = {0, 0, 0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS)};
+        delta4d = {Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS),
-                   Math::Random::Uniform<double>()(xoshiro256SS)};
+        delta4d = {Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS),
+                   Random::Uniform<double>()(xoshiro256SS)};
         v4d += delta4d;
     }
     time = stopwatch.read();

--- a/test/Math/Random/Generator/Xoshiro512Plus.c++
+++ b/test/Math/Random/Generator/Xoshiro512Plus.c++
@@ -33,8 +33,8 @@
 using namespace Mustard;
 
 int main() {
-    Math::Random::MT1993732 mt1993732;
-    Math::Random::Xoshiro512Plus xoshiro512Plus;
+    Random::MT1993732 mt1993732;
+    Random::Xoshiro512Plus xoshiro512Plus;
 
     std::cout << "Simply generate 10 million integers:" << std::endl;
 
@@ -112,14 +112,14 @@ int main() {
     Eigen::RowVector2d delta2d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta2d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta2d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -127,14 +127,14 @@ int main() {
 
     v2d = {0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro512Plus),
-                   Math::Random::Uniform<double>()(xoshiro512Plus)};
+        delta2d = {Random::Uniform<double>()(xoshiro512Plus),
+                   Random::Uniform<double>()(xoshiro512Plus)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro512Plus),
-                   Math::Random::Uniform<double>()(xoshiro512Plus)};
+        delta2d = {Random::Uniform<double>()(xoshiro512Plus),
+                   Random::Uniform<double>()(xoshiro512Plus)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -145,16 +145,16 @@ int main() {
     Eigen::RowVector3d delta3d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta3d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta3d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -162,16 +162,16 @@ int main() {
 
     v3d = {0, 0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro512Plus),
-                   Math::Random::Uniform<double>()(xoshiro512Plus),
-                   Math::Random::Uniform<double>()(xoshiro512Plus)};
+        delta3d = {Random::Uniform<double>()(xoshiro512Plus),
+                   Random::Uniform<double>()(xoshiro512Plus),
+                   Random::Uniform<double>()(xoshiro512Plus)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro512Plus),
-                   Math::Random::Uniform<double>()(xoshiro512Plus),
-                   Math::Random::Uniform<double>()(xoshiro512Plus)};
+        delta3d = {Random::Uniform<double>()(xoshiro512Plus),
+                   Random::Uniform<double>()(xoshiro512Plus),
+                   Random::Uniform<double>()(xoshiro512Plus)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -182,18 +182,18 @@ int main() {
     Eigen::RowVector4d delta4d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta4d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta4d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v4d += delta4d;
     }
     time = stopwatch.read();
@@ -201,18 +201,18 @@ int main() {
 
     v4d = {0, 0, 0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro512Plus),
-                   Math::Random::Uniform<double>()(xoshiro512Plus),
-                   Math::Random::Uniform<double>()(xoshiro512Plus),
-                   Math::Random::Uniform<double>()(xoshiro512Plus)};
+        delta4d = {Random::Uniform<double>()(xoshiro512Plus),
+                   Random::Uniform<double>()(xoshiro512Plus),
+                   Random::Uniform<double>()(xoshiro512Plus),
+                   Random::Uniform<double>()(xoshiro512Plus)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro512Plus),
-                   Math::Random::Uniform<double>()(xoshiro512Plus),
-                   Math::Random::Uniform<double>()(xoshiro512Plus),
-                   Math::Random::Uniform<double>()(xoshiro512Plus)};
+        delta4d = {Random::Uniform<double>()(xoshiro512Plus),
+                   Random::Uniform<double>()(xoshiro512Plus),
+                   Random::Uniform<double>()(xoshiro512Plus),
+                   Random::Uniform<double>()(xoshiro512Plus)};
         v4d += delta4d;
     }
     time = stopwatch.read();

--- a/test/Math/Random/Generator/Xoshiro512PlusPlus.c++
+++ b/test/Math/Random/Generator/Xoshiro512PlusPlus.c++
@@ -33,8 +33,8 @@
 using namespace Mustard;
 
 int main() {
-    Math::Random::MT1993732 mt1993732;
-    Math::Random::Xoshiro512PlusPlus xoshiro512PP;
+    Random::MT1993732 mt1993732;
+    Random::Xoshiro512PlusPlus xoshiro512PP;
 
     std::cout << "Simply generate 10 million integers:" << std::endl;
 
@@ -112,14 +112,14 @@ int main() {
     Eigen::RowVector2d delta2d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta2d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta2d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -127,14 +127,14 @@ int main() {
 
     v2d = {0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro512PP),
-                   Math::Random::Uniform<double>()(xoshiro512PP)};
+        delta2d = {Random::Uniform<double>()(xoshiro512PP),
+                   Random::Uniform<double>()(xoshiro512PP)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro512PP),
-                   Math::Random::Uniform<double>()(xoshiro512PP)};
+        delta2d = {Random::Uniform<double>()(xoshiro512PP),
+                   Random::Uniform<double>()(xoshiro512PP)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -145,16 +145,16 @@ int main() {
     Eigen::RowVector3d delta3d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta3d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta3d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -162,16 +162,16 @@ int main() {
 
     v3d = {0, 0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro512PP),
-                   Math::Random::Uniform<double>()(xoshiro512PP),
-                   Math::Random::Uniform<double>()(xoshiro512PP)};
+        delta3d = {Random::Uniform<double>()(xoshiro512PP),
+                   Random::Uniform<double>()(xoshiro512PP),
+                   Random::Uniform<double>()(xoshiro512PP)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro512PP),
-                   Math::Random::Uniform<double>()(xoshiro512PP),
-                   Math::Random::Uniform<double>()(xoshiro512PP)};
+        delta3d = {Random::Uniform<double>()(xoshiro512PP),
+                   Random::Uniform<double>()(xoshiro512PP),
+                   Random::Uniform<double>()(xoshiro512PP)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -182,18 +182,18 @@ int main() {
     Eigen::RowVector4d delta4d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta4d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta4d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v4d += delta4d;
     }
     time = stopwatch.read();
@@ -201,18 +201,18 @@ int main() {
 
     v4d = {0, 0, 0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro512PP),
-                   Math::Random::Uniform<double>()(xoshiro512PP),
-                   Math::Random::Uniform<double>()(xoshiro512PP),
-                   Math::Random::Uniform<double>()(xoshiro512PP)};
+        delta4d = {Random::Uniform<double>()(xoshiro512PP),
+                   Random::Uniform<double>()(xoshiro512PP),
+                   Random::Uniform<double>()(xoshiro512PP),
+                   Random::Uniform<double>()(xoshiro512PP)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro512PP),
-                   Math::Random::Uniform<double>()(xoshiro512PP),
-                   Math::Random::Uniform<double>()(xoshiro512PP),
-                   Math::Random::Uniform<double>()(xoshiro512PP)};
+        delta4d = {Random::Uniform<double>()(xoshiro512PP),
+                   Random::Uniform<double>()(xoshiro512PP),
+                   Random::Uniform<double>()(xoshiro512PP),
+                   Random::Uniform<double>()(xoshiro512PP)};
         v4d += delta4d;
     }
     time = stopwatch.read();

--- a/test/Math/Random/Generator/Xoshiro512StarStar.c++
+++ b/test/Math/Random/Generator/Xoshiro512StarStar.c++
@@ -33,8 +33,8 @@
 using namespace Mustard;
 
 int main() {
-    Math::Random::MT1993732 mt1993732;
-    Math::Random::Xoshiro512StarStar xoshiro512SS;
+    Random::MT1993732 mt1993732;
+    Random::Xoshiro512StarStar xoshiro512SS;
 
     std::cout << "Simply generate 10 million integers:" << std::endl;
 
@@ -112,14 +112,14 @@ int main() {
     Eigen::RowVector2d delta2d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta2d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta2d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -127,14 +127,14 @@ int main() {
 
     v2d = {0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS)};
+        delta2d = {Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS)};
         v2d += delta2d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta2d = {Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS)};
+        delta2d = {Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS)};
         v2d += delta2d;
     }
     time = stopwatch.read();
@@ -145,16 +145,16 @@ int main() {
     Eigen::RowVector3d delta3d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta3d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta3d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -162,16 +162,16 @@ int main() {
 
     v3d = {0, 0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS)};
+        delta3d = {Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS)};
         v3d += delta3d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta3d = {Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS)};
+        delta3d = {Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS)};
         v3d += delta3d;
     }
     time = stopwatch.read();
@@ -182,18 +182,18 @@ int main() {
     Eigen::RowVector4d delta4d;
 
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta4d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732),
-                   Math::Random::Uniform<double>()(mt1993732)};
+        delta4d = {Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732),
+                   Random::Uniform<double>()(mt1993732)};
         v4d += delta4d;
     }
     time = stopwatch.read();
@@ -201,18 +201,18 @@ int main() {
 
     v4d = {0, 0, 0, 0};
     for (int i = 0; i < 1'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS)};
+        delta4d = {Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS)};
         v4d += delta4d;
     }
     stopwatch = {};
     for (int i = 0; i < 10'000'000; ++i) {
-        delta4d = {Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS),
-                   Math::Random::Uniform<double>()(xoshiro512SS)};
+        delta4d = {Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS),
+                   Random::Uniform<double>()(xoshiro512SS)};
         v4d += delta4d;
     }
     time = stopwatch.read();

--- a/test/Math/Random/RandomNumberDistribution.c++
+++ b/test/Math/Random/RandomNumberDistribution.c++
@@ -26,8 +26,8 @@
 using namespace Mustard;
 
 int main(int, char* argv[]) {
-    Math::Random::Xoshiro256Plus rng;
-    // Math::Random::MT1993732 rng;
+    Random::Xoshiro256Plus rng;
+    // Random::MT1993732 rng;
 
     using RNG = decltype(rng);
 
@@ -44,31 +44,31 @@ int main(int, char* argv[]) {
             std::cout << a << std::endl;
             throw "Failed";
         }
-        a = Math::Random::Uniform<double>()(rng);
+        a = Random::Uniform<double>()(rng);
     }
-    Math::Random::Uniform<double>().Reset();
+    Random::Uniform<double>().Reset();
     std::cout << a << std::endl;
 
     return 0;
 }
 
-static_assert(Math::Random::STDRandomNumberDistribution<std::uniform_int_distribution<int>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::uniform_real_distribution<double>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::bernoulli_distribution>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::binomial_distribution<int>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::negative_binomial_distribution<int>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::geometric_distribution<int>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::poisson_distribution<int>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::exponential_distribution<double>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::gamma_distribution<double>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::weibull_distribution<double>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::extreme_value_distribution<double>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::normal_distribution<double>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::lognormal_distribution<double>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::chi_squared_distribution<double>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::cauchy_distribution<double>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::fisher_f_distribution<double>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::student_t_distribution<double>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::discrete_distribution<int>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::piecewise_constant_distribution<double>>);
-static_assert(Math::Random::STDRandomNumberDistribution<std::piecewise_linear_distribution<double>>);
+static_assert(Random::STDRandomNumberDistribution<std::uniform_int_distribution<int>>);
+static_assert(Random::STDRandomNumberDistribution<std::uniform_real_distribution<double>>);
+static_assert(Random::STDRandomNumberDistribution<std::bernoulli_distribution>);
+static_assert(Random::STDRandomNumberDistribution<std::binomial_distribution<int>>);
+static_assert(Random::STDRandomNumberDistribution<std::negative_binomial_distribution<int>>);
+static_assert(Random::STDRandomNumberDistribution<std::geometric_distribution<int>>);
+static_assert(Random::STDRandomNumberDistribution<std::poisson_distribution<int>>);
+static_assert(Random::STDRandomNumberDistribution<std::exponential_distribution<double>>);
+static_assert(Random::STDRandomNumberDistribution<std::gamma_distribution<double>>);
+static_assert(Random::STDRandomNumberDistribution<std::weibull_distribution<double>>);
+static_assert(Random::STDRandomNumberDistribution<std::extreme_value_distribution<double>>);
+static_assert(Random::STDRandomNumberDistribution<std::normal_distribution<double>>);
+static_assert(Random::STDRandomNumberDistribution<std::lognormal_distribution<double>>);
+static_assert(Random::STDRandomNumberDistribution<std::chi_squared_distribution<double>>);
+static_assert(Random::STDRandomNumberDistribution<std::cauchy_distribution<double>>);
+static_assert(Random::STDRandomNumberDistribution<std::fisher_f_distribution<double>>);
+static_assert(Random::STDRandomNumberDistribution<std::student_t_distribution<double>>);
+static_assert(Random::STDRandomNumberDistribution<std::discrete_distribution<int>>);
+static_assert(Random::STDRandomNumberDistribution<std::piecewise_constant_distribution<double>>);
+static_assert(Random::STDRandomNumberDistribution<std::piecewise_linear_distribution<double>>);


### PR DESCRIPTION
## Summary
This pull request refactors the codebase to consistently use the `inline` namespace for `Mustard::Math`, and replaces references to CLHEP vector types with Mustard vector aliases. It also updates usages of the `Math::Random` namespace to `Random`. Additionally, the pull request adds a "Refactor" option to the pull request template and updates a badge color in the `README.md`.

### Namespace and Type Refactoring

* Changed all occurrences of `namespace Mustard::Math` and its submodules to `namespace Mustard::inline Math`, including in files such as `Estimate.h++`, `GeometryRepresentation.h++`, `MCIntegrationUtility.h++`, `POCA.h++`, and their corresponding implementation files. This ensures consistent usage of the inline namespace throughout the codebase. [[1]](diffhunk://#diff-1c5ef372e5320a866ee41e4ac3dea65fa0436945c1920a806027d2563cb3a961L27-R27) [[2]](diffhunk://#diff-1c5ef372e5320a866ee41e4ac3dea65fa0436945c1920a806027d2563cb3a961L259-R259) [[3]](diffhunk://#diff-998e6a4b256b2d638e03b43a6052a23a04d3c7efe2cf61a2392a6439c5993f34L21-R28) [[4]](diffhunk://#diff-998e6a4b256b2d638e03b43a6052a23a04d3c7efe2cf61a2392a6439c5993f34L143-R136) [[5]](diffhunk://#diff-91643a3cbeaa5a80ab3b0a337c98864fc4c8d4c0703bff706690947dbbec1939L25-R33) [[6]](diffhunk://#diff-c9f4376c445b4280a445d4b2c3192df16bf3dbfce29f29a4c5e2675a6c247b1cL27-R27) [[7]](diffhunk://#diff-c9f4376c445b4280a445d4b2c3192df16bf3dbfce29f29a4c5e2675a6c247b1cL120-R120) [[8]](diffhunk://#diff-3f45cb2bbd5c2a51d315632bfe526c18e501e5a6f633b6a67761ae32034be831L30-R30) [[9]](diffhunk://#diff-3f45cb2bbd5c2a51d315632bfe526c18e501e5a6f633b6a67761ae32034be831L255-R255)
* Updated all `Math::Random` references to `Random` in files such as `MersenneTwister.h++`, `Wrap.h++`, `MuoniumTransport.h++`, and `MuoniumTransport.inl`, simplifying the namespace usage for random number generators and distributions. [[1]](diffhunk://#diff-2643c5dc03bb8d8b695878b0c6ca3886be05a534e4866c73bfe2fa0cdc53d7e4L27-R28) [[2]](diffhunk://#diff-272c3d881335c233bdfda88ba3465bc871d17c731f5de54707f855c0f8c961e2L49-R49) [[3]](diffhunk://#diff-09e9b224c0f04e202f5a5bf16ea929126492548862f748427b5a65bdf5ed1a15L77-R78) [[4]](diffhunk://#diff-f647b5e72ab6d58bb433316f2ae76aacae01e08b670645a22c9cf377abc5c5f1L130-R131)

### Vector Type Migration

* Replaced CLHEP vector types (`CLHEP::Hep2Vector`, `CLHEP::Hep3Vector`) with Mustard vector aliases by including `Mustard/Math/Vector.h++` and updating type aliases in `GeometryRepresentation.h++`. [[1]](diffhunk://#diff-998e6a4b256b2d638e03b43a6052a23a04d3c7efe2cf61a2392a6439c5993f34L21-R28) [[2]](diffhunk://#diff-998e6a4b256b2d638e03b43a6052a23a04d3c7efe2cf61a2392a6439c5993f34L50-L52)

### Random Distribution Namespace Updates

* Refactored namespaces for all random distribution headers and implementation files to use `Mustard::inline Math::Random::inline Distribution`, including exponential, Gaussian, 2D and 3D diagonal Gaussian distributions. [[1]](diffhunk://#diff-cffd7e05230def29b7cfd4e07ae87bb0f48dadf22b2c2c6a8da0b7e99fc15ea7L35-R35) [[2]](diffhunk://#diff-cffd7e05230def29b7cfd4e07ae87bb0f48dadf22b2c2c6a8da0b7e99fc15ea7L169-R169) [[3]](diffhunk://#diff-11a51663b0f3628f5fd27a35e04589ebf1810b13bf912a9f3c5cb915417766afL19-R19) [[4]](diffhunk://#diff-11a51663b0f3628f5fd27a35e04589ebf1810b13bf912a9f3c5cb915417766afL72-R72) [[5]](diffhunk://#diff-6c336d14c0daecb1bedd6a3120d57b451dc7ec75fde86c7d70153116a1b5971cL32-R32) [[6]](diffhunk://#diff-6c336d14c0daecb1bedd6a3120d57b451dc7ec75fde86c7d70153116a1b5971cL194-R194) [[7]](diffhunk://#diff-b443a018a2f3df257709862a0436e5078ec0d5f84661412dae429031668df200L19-R19) [[8]](diffhunk://#diff-b443a018a2f3df257709862a0436e5078ec0d5f84661412dae429031668df200L77-R77) [[9]](diffhunk://#diff-17e55ac8b7b4ae1cdaf92ba8a061551ec64f834b908f6e46f09551768ae97158L38-R38) [[10]](diffhunk://#diff-17e55ac8b7b4ae1cdaf92ba8a061551ec64f834b908f6e46f09551768ae97158L200-R200) [[11]](diffhunk://#diff-77ecb1a46962c540da74b85a1427cda193f3718dc37176fbca1c93a74a7f7cb6L19-R19) [[12]](diffhunk://#diff-77ecb1a46962c540da74b85a1427cda193f3718dc37176fbca1c93a74a7f7cb6L88-R88) [[13]](diffhunk://#diff-13dcf5feb2a9a026256fcfddc9f501870f498143a16a3b5bfbd40fc1be78aad5L35-R35) [[14]](diffhunk://#diff-13dcf5feb2a9a026256fcfddc9f501870f498143a16a3b5bfbd40fc1be78aad5L215-R215) [[15]](diffhunk://#diff-33be03144f69c6aa07828f17d89bffdc9a1559a1d25e41d009e8c1f7e46da7c1L19-R19) [[16]](diffhunk://#diff-33be03144f69c6aa07828f17d89bffdc9a1559a1d25e41d009e8c1f7e46da7c1L98-R98)

### Others

* Added a "Refactor" option to the pull request template in `.github/pull_request_template.md` to clarify the nature of changes in future PRs.
* Updated the "Created At" badge color from green to blue in `README.md` for improved visual distinction.

## Type of change
- Refactor (non-breaking change which optimizes code structure)
