### PR TITLE
Add radiative muon decay generator and update event generator interface

### DIFF
--- a/src/Mustard/Math/MCIntegrationUtility.h++
+++ b/src/Mustard/Math/MCIntegrationUtility.h++
@@ -20,14 +20,13 @@
 
 #include "Mustard/Math/Estimate.h++"
 
-#include "muc/array"
-
 namespace Mustard::inline Math {
 
 /// @brief Monte Carlo integration internal state
 struct MCIntegrationState {
-    muc::array2d sum;     ///< Sum of integrand and squared integrand
-    unsigned long long n; ///< Sample size
+    double sumF{};          ///< Sum of integrand
+    double sumF2{};         ///< Sum of squared integrand
+    unsigned long long n{}; ///< Sample size
 };
 
 } // namespace Mustard::inline Math

--- a/src/Mustard/Math/Random/Distribution/Gaussian2DDiagnoal.inl
+++ b/src/Mustard/Math/Random/Distribution/Gaussian2DDiagnoal.inl
@@ -66,8 +66,8 @@ constexpr Gaussian2DDiagnoalBase<ADerived, T>::Gaussian2DDiagnoalBase(const type
         static_assert(UniformCompactRectangle<T>::Stateless());                         \
         u = UniformCompactRectangle<T>({-0.5, 0.5}, {-0.5, 0.5})(g);                    \
         x = muc::hypot_sq(u[0], u[1]);                                                  \
-        muc::assume(0 <= x and x < 0.5);                                                \
-    } while (x == 0 or x > 0.25);                                                       \
+        muc::assume(0 <= x and x <= 0.5);                                               \
+    } while (x == 0 or x >= 0.25);                                                      \
     x = std::sqrt(-2 * (TheLog(x) + 2 * std::numbers::ln2_v<VT>) / x);                  \
     u[0] = p.SigmaX() * (x * u[0]) + p.MuX();                                           \
     u[1] = p.SigmaY() * (x * u[1]) + p.MuY();                                           \

--- a/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.h++
+++ b/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.h++
@@ -125,7 +125,7 @@ private:
     auto NextEventImpl(CLHEP::HepRandomEngine& rng, double burnInStepSize = 0) -> bool;
 
 private:
-    Random::Gaussian<double> fGaussian;                                            ///< Gaussian distribution
+    Random::GaussianFast<double> fGaussian;                                        ///< Gaussian distribution
     unsigned long long fIteration;                                                 ///< Current iteration count
     double fLearningRate;                                                          ///< Learning rate for adaptation
     Eigen::Vector<double, MarkovChain::dim> fRunningMean;                          ///< Running mean of states

--- a/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.h++
+++ b/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.h++
@@ -76,7 +76,7 @@ public:
     /// @param pI initial-state 4-momenta
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
+    /// @param thinningRatio Thinning factor (non-negative, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     AdaptiveMTMGenerator(const InitialStateMomenta& pI, const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                          std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {});
@@ -85,7 +85,7 @@ public:
     /// @param polarization Initial-state polarization vector(s)
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
+    /// @param thinningRatio Thinning factor (non-negative, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @note This overload is only enabled for polarized decay
     AdaptiveMTMGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,

--- a/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.h++
+++ b/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.h++
@@ -82,28 +82,16 @@ public:
                          std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {});
     /// @brief Construct event generator
     /// @param pI initial-state 4-momenta
-    /// @param polarization Initial-state polarization vector
+    /// @param polarization Initial-state polarization vector(s)
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
     /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @note This overload is only enabled for polarized decay
-    AdaptiveMTMGenerator(const InitialStateMomenta& pI, Vector3D polarization,
+    AdaptiveMTMGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                          const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                          std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {})
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
-    /// @brief Construct event generator
-    /// @param pI initial-state 4-momenta
-    /// @param polarization Initial-state polarization vectors
-    /// @param pdgID Array of particle PDG IDs (index order preserved)
-    /// @param mass Array of particle masses (index order preserved)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
-    /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
-    /// @note This overload is only enabled for polarized scattering
-    AdaptiveMTMGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
-                         const std::array<int, N>& pdgID, const std::array<double, N>& mass,
-                         std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {})
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
+        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>>;
 
     // Keep the class abstract
     virtual ~AdaptiveMTMGenerator() override = 0;

--- a/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.inl
+++ b/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.inl
@@ -30,23 +30,10 @@ AdaptiveMTMGenerator<M, N, A>::AdaptiveMTMGenerator(const InitialStateMomenta& p
     fProposalSigma{} {}
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-AdaptiveMTMGenerator<M, N, A>::AdaptiveMTMGenerator(const InitialStateMomenta& pI, Vector3D polarization,
+AdaptiveMTMGenerator<M, N, A>::AdaptiveMTMGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                                                     const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                                     std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize) // clang-format off
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> : // clang-format on
-    Base{pI, polarization, pdgID, mass, std::move(thinningRatio), std::move(acfSampleSize)},
-    fGaussian{},
-    fIteration{},
-    fLearningRate{},
-    fRunningMean{},
-    fProposalCovariance{},
-    fProposalSigma{} {}
-
-template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-AdaptiveMTMGenerator<M, N, A>::AdaptiveMTMGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
-                                                    const std::array<int, N>& pdgID, const std::array<double, N>& mass,
-                                                    std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize) // clang-format off
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) : // clang-format on
+    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> : // clang-format on
     Base{pI, polarization, pdgID, mass, std::move(thinningRatio), std::move(acfSampleSize)},
     fGaussian{},
     fIteration{},

--- a/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.inl
+++ b/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.inl
@@ -52,7 +52,7 @@ auto AdaptiveMTMGenerator<M, N, A>::BurnIn(CLHEP::HepRandomEngine& rng) -> void 
     // i.e. sqrt(random walk distance) >~ scale * sqrt(dimension)
     constexpr auto travelScale{10};
     double distance{};
-    while (distance > muc::pow(travelScale, 2) * MarkovChain::dim) {
+    while (distance < muc::pow(travelScale, 2) * MarkovChain::dim) {
         if (NextEventImpl(rng, fgInitProposalStepSize)) {
             distance += fgInitProposalStepSize;
         }

--- a/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.inl
+++ b/src/Mustard/Physics/Generator/AdaptiveMTMGenerator.inl
@@ -121,12 +121,12 @@ auto AdaptiveMTMGenerator<M, N, A>::NextEventImpl(CLHEP::HepRandomEngine& rng, d
         }
         double detJ;
         std::tie(eventY[i], detJ) = this->PhaseSpace(stateY[i]); // y_i -> event(y_i) = g(y_i), also get |J|(g(y_i))
-        if (not this->IRSafe(eventY[i].p)) {
+        if (not this->InfraredSafe(eventY[i].p)) {
             piY[i] = 0;
             continue;
         }
-        acceptanceY[i] = this->ValidAcceptance(eventY[i].p);                      // g(y_i) -> B(g(y_i))
-        piY[i] = this->ValidMSqAcceptanceDetJ(eventY[i].p, acceptanceY[i], detJ); // g(y_i) -> pi(y_i) = |M|²(g(y_i)) × B(g(y_i)) × |J|(g(y_i))
+        acceptanceY[i] = this->Acceptance(eventY[i].p);                      // g(y_i) -> B(g(y_i))
+        piY[i] = this->MSqAcceptanceDetJ(eventY[i].p, acceptanceY[i], detJ); // g(y_i) -> pi(y_i) = |M|²(g(y_i)) × B(g(y_i)) × |J|(g(y_i))
     }
     const auto sumPiY{muc::ranges::reduce(piY)}; // pi(y_1) + ... + pi(y_k)
     const auto selected{[&] {                    // Select Y from y_1, ..., y_k by pi(y_1), ..., pi(y_k)
@@ -148,11 +148,11 @@ auto AdaptiveMTMGenerator<M, N, A>::NextEventImpl(CLHEP::HepRandomEngine& rng, d
             continue;
         }
         const auto [event, detJ]{this->PhaseSpace(stateX)}; // x_i -> event(x_i) = g(x_i), also get |J|(g(x_i))
-        if (not this->IRSafe(event.p)) {
+        if (not this->InfraredSafe(event.p)) {
             continue;
         }
-        const auto acceptanceX{this->ValidAcceptance(event.p)};             // g(x_i) -> B(g(x_i))
-        sumPiX += this->ValidMSqAcceptanceDetJ(event.p, acceptanceX, detJ); // g(x_i) -> pi(x_i) = |M|²(g(x_i)) × B(g(x_i)) × |J|(g(y_i))
+        const auto acceptanceX{this->Acceptance(event.p)};             // g(x_i) -> B(g(x_i))
+        sumPiX += this->MSqAcceptanceDetJ(event.p, acceptanceX, detJ); // g(x_i) -> pi(x_i) = |M|²(g(x_i)) × B(g(x_i)) × |J|(g(y_i))
     }
 
     // accept/reject Y

--- a/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.h++
+++ b/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.h++
@@ -124,8 +124,8 @@ private:
     virtual auto NextEvent(CLHEP::HepRandomEngine& rng) -> bool override;
 
 private:
-    Random::Gaussian<double> fGaussian; ///< Gaussian distribution
-    double fStepSize;                   ///< Step scale along one direction in random state space
+    Random::GaussianFast<double> fGaussian; ///< Gaussian distribution
+    double fStepSize;                       ///< Step scale along one direction in random state space
 
     static inline const auto fgScalingFactor{2.38 / std::sqrt(MarkovChain::dim)}; ///< Step size scaling factor
 };

--- a/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.h++
+++ b/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.h++
@@ -72,7 +72,7 @@ public:
     /// @param pI initial-state 4-momenta
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
+    /// @param thinningRatio Thinning factor (non-negative, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     ClassicalMetropolisGenerator(const InitialStateMomenta& pI, const std::array<int, N>& pdgID, const std::array<double, N>& mass,
@@ -83,7 +83,7 @@ public:
     /// @param polarization Initial-state polarization vector(s)
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
+    /// @param thinningRatio Thinning factor (non-negative, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     /// @note This overload is only enabled for polarized decay

--- a/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.h++
+++ b/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.h++
@@ -80,32 +80,18 @@ public:
                                  std::optional<double> stepSize = {});
     /// @brief Construct event generator
     /// @param pI initial-state 4-momenta
-    /// @param polarization Initial-state polarization vector
+    /// @param polarization Initial-state polarization vector(s)
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
     /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     /// @note This overload is only enabled for polarized decay
-    ClassicalMetropolisGenerator(const InitialStateMomenta& pI, Vector3D polarization,
+    ClassicalMetropolisGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                                  const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                  std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {},
                                  std::optional<double> stepSize = {})
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
-    /// @brief Construct event generator
-    /// @param pI initial-state 4-momenta
-    /// @param polarization Initial-state polarization vectors
-    /// @param pdgID Array of particle PDG IDs (index order preserved)
-    /// @param mass Array of particle masses (index order preserved)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
-    /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
-    /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
-    /// @note This overload is only enabled for polarized scattering
-    ClassicalMetropolisGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
-                                 const std::array<int, N>& pdgID, const std::array<double, N>& mass,
-                                 std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {},
-                                 std::optional<double> stepSize = {})
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
+        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>>;
 
     // Keep the class abstract
     virtual ~ClassicalMetropolisGenerator() override = 0;

--- a/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.inl
+++ b/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.inl
@@ -31,25 +31,11 @@ ClassicalMetropolisGenerator<M, N, A>::ClassicalMetropolisGenerator(const Initia
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-ClassicalMetropolisGenerator<M, N, A>::ClassicalMetropolisGenerator(const InitialStateMomenta& pI, Vector3D polarization,
+ClassicalMetropolisGenerator<M, N, A>::ClassicalMetropolisGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                                                                     const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                                                     std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize,
                                                                     std::optional<double> stepSize) // clang-format off
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> : // clang-format on
-    Base{pI, polarization, pdgID, mass, std::move(thinningRatio), std::move(acfSampleSize)},
-    fGaussian{},
-    fStepSize{std::numeric_limits<double>::quiet_NaN()} {
-    if (stepSize) {
-        StepSize(*stepSize);
-    }
-}
-
-template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-ClassicalMetropolisGenerator<M, N, A>::ClassicalMetropolisGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
-                                                                    const std::array<int, N>& pdgID, const std::array<double, N>& mass,
-                                                                    std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize,
-                                                                    std::optional<double> stepSize) // clang-format off
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) : // clang-format on
+    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> : // clang-format on
     Base{pI, polarization, pdgID, mass, std::move(thinningRatio), std::move(acfSampleSize)},
     fGaussian{},
     fStepSize{std::numeric_limits<double>::quiet_NaN()} {

--- a/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.inl
+++ b/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.inl
@@ -106,9 +106,9 @@ auto ClassicalMetropolisGenerator<M, N, A>::NextEvent(CLHEP::HepRandomEngine& rn
     this->ProposePID(rng, this->fMC.state.pID, state.pID);
     auto [event, detJ]{this->PhaseSpace(state)};
     bool accepted{};
-    if (this->IRSafe(event.p)) {
-        const auto acceptance{this->ValidAcceptance(event.p)};
-        const auto mSqAcceptanceDetJ{this->ValidMSqAcceptanceDetJ(event.p, acceptance, detJ)};
+    if (this->InfraredSafe(event.p)) {
+        const auto acceptance{this->Acceptance(event.p)};
+        const auto mSqAcceptanceDetJ{this->MSqAcceptanceDetJ(event.p, acceptance, detJ)};
         if (mSqAcceptanceDetJ >= this->fMC.mSqAcceptanceDetJ or
             mSqAcceptanceDetJ > this->fMC.mSqAcceptanceDetJ * rng.flat()) {
             this->fMC.state = std::move(state);

--- a/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.inl
+++ b/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.inl
@@ -50,7 +50,8 @@ ClassicalMetropolisGenerator<M, N, A>::~ClassicalMetropolisGenerator() = default
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto ClassicalMetropolisGenerator<M, N, A>::StepSize(double stepSize) -> void {
     if (not std::isfinite(stepSize)) [[unlikely]] {
-        PrintError(fmt::format("Infinite MCMC step size (got {})", stepSize));
+        PrintError(fmt::format("Infinite MCMC step size not allowed (got {}), not setting it", stepSize));
+        return;
     }
     if (stepSize <= muc::default_tolerance<double> or 0.5 <= stepSize) [[unlikely]] {
         PrintWarning(fmt::format("Suspicious MCMC step size (got {}, expects {} < step size < 0.5)", stepSize, muc::default_tolerance<double>));
@@ -67,7 +68,7 @@ auto ClassicalMetropolisGenerator<M, N, A>::BurnIn(CLHEP::HepRandomEngine& rng) 
     // i.e. sqrt(random walk distance) >~ scale * sqrt(dimension)
     constexpr auto travelScale{10};
     double distance{};
-    while (distance > muc::pow(travelScale, 2) * MarkovChain::dim) {
+    while (distance < muc::pow(travelScale, 2) * MarkovChain::dim) {
         if (NextEvent(rng)) {
             distance += fStepSize;
         }

--- a/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.inl
+++ b/src/Mustard/Physics/Generator/ClassicalMetropolisGenerator.inl
@@ -50,7 +50,7 @@ ClassicalMetropolisGenerator<M, N, A>::~ClassicalMetropolisGenerator() = default
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto ClassicalMetropolisGenerator<M, N, A>::StepSize(double stepSize) -> void {
     if (not std::isfinite(stepSize)) [[unlikely]] {
-        PrintError(fmt::format("Infinite MCMC step size not allowed (got {}), not setting it", stepSize));
+        PrintError(fmt::format("Non-finite MCMC step size not allowed (got {}), not setting it", stepSize));
         return;
     }
     if (stepSize <= muc::default_tolerance<double> or 0.5 <= stepSize) [[unlikely]] {

--- a/src/Mustard/Physics/Generator/EventGenerator.h++
+++ b/src/Mustard/Physics/Generator/EventGenerator.h++
@@ -152,7 +152,7 @@ public:
     /// @param pI Initial-state 4-momenta (maybe ignored, depend on specific generator)
     /// @return Generated event
     virtual auto operator()(CLHEP::HepRandomEngine& rng, InitialStateMomenta pI) -> Event override;
-    // Inherit operator() overloads
+    // Avoid hiding other operator() overloads from base class
     using EventGenerator<M, N>::operator();
 };
 

--- a/src/Mustard/Physics/Generator/GENBOD.h++
+++ b/src/Mustard/Physics/Generator/GENBOD.h++
@@ -88,7 +88,7 @@ public:
     /// @param pI Initial-state 4-momenta
     /// @return Generated event
     virtual auto operator()(const RandomState& u, InitialStateMomenta pI) -> Event override;
-    // Inherit operator() overloads
+    // Avoid hiding other operator() overloads from base class
     using VersatileEventGenerator<M, N, 3 * N - 4>::operator();
 };
 

--- a/src/Mustard/Physics/Generator/M2ENNEEGenerator.c++
+++ b/src/Mustard/Physics/Generator/M2ENNEEGenerator.c++
@@ -40,7 +40,7 @@ M2ENNEEGenerator::M2ENNEEGenerator(std::string_view parent, Vector3D momentum, V
         MSqVersion(*mSqVer);
     }
     Parent(parent);
-    ParentMomentum(momentum);
+    Momentum(momentum);
     Mass({electron_mass_c2, 0, 0, electron_mass_c2, electron_mass_c2});
     AddIdenticalSet({0, 4});
 }
@@ -55,9 +55,9 @@ auto M2ENNEEGenerator::Parent(std::string_view parent) -> void {
     }
 }
 
-auto M2ENNEEGenerator::ParentMomentum(Vector3D momentum) -> void {
+auto M2ENNEEGenerator::Momentum(Vector3D momentum) -> void {
     const auto energy{std::sqrt(momentum.mag2() + muc::pow(muon_mass_c2, 2))};
-    ISMomenta({energy, momentum});
+    Momenta({energy, momentum});
 }
 
 } // namespace Mustard::inline Physics::inline Generator

--- a/src/Mustard/Physics/Generator/M2ENNEEGenerator.h++
+++ b/src/Mustard/Physics/Generator/M2ENNEEGenerator.h++
@@ -37,7 +37,7 @@ public:
     /// @param parent "mu-" or "mu+" (determines PDG IDs in generated event)
     /// @param momentum Muon momentum
     /// @param polarization Muon polarization vector
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
+    /// @param thinningRatio Thinning factor (non-negative, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     /// @param mSqVer The matrix element version

--- a/src/Mustard/Physics/Generator/M2ENNEEGenerator.h++
+++ b/src/Mustard/Physics/Generator/M2ENNEEGenerator.h++
@@ -55,7 +55,7 @@ public:
     auto Parent(std::string_view parent) -> void;
     /// @brief Set parent momentum
     /// @param momentum Muon momentum
-    auto ParentMomentum(Vector3D momentum) -> void;
+    auto Momentum(Vector3D momentum) -> void;
 };
 
 } // namespace Mustard::inline Physics::inline Generator

--- a/src/Mustard/Physics/Generator/M2ENNEGenerator.c++
+++ b/src/Mustard/Physics/Generator/M2ENNEGenerator.c++
@@ -37,7 +37,7 @@ M2ENNEGenerator::M2ENNEGenerator(std::string_view parent, Vector3D momentum,
                                  std::optional<double> stepSize) :
     MultipleTryMetropolisGenerator{{}, {}, {}, thinningRatio, acfSampleSize.value_or(100000), stepSize.value_or(0.1)} {
     Parent(parent);
-    ParentMomentum(momentum);
+    Momentum(momentum);
     Mass({electron_mass_c2, 0, 0, electron_mass_c2});
 }
 
@@ -51,9 +51,9 @@ auto M2ENNEGenerator::Parent(std::string_view parent) -> void {
     }
 }
 
-auto M2ENNEGenerator::ParentMomentum(Vector3D momentum) -> void {
+auto M2ENNEGenerator::Momentum(Vector3D momentum) -> void {
     const auto energy{std::sqrt(momentum.mag2() + muc::pow(muonium_mass_c2, 2))};
-    ISMomenta({energy, momentum});
+    Momenta({energy, momentum});
 }
 
 } // namespace Mustard::inline Physics::inline Generator

--- a/src/Mustard/Physics/Generator/M2ENNEGenerator.h++
+++ b/src/Mustard/Physics/Generator/M2ENNEGenerator.h++
@@ -48,7 +48,7 @@ public:
     auto Parent(std::string_view parent) -> void;
     /// @brief Set parent momentum
     /// @param momentum Muonium momentum
-    auto ParentMomentum(Vector3D momentum) -> void;
+    auto Momentum(Vector3D momentum) -> void;
 };
 
 } // namespace Mustard::inline Physics::inline Generator

--- a/src/Mustard/Physics/Generator/M2ENNEGenerator.h++
+++ b/src/Mustard/Physics/Generator/M2ENNEGenerator.h++
@@ -35,7 +35,7 @@ public:
     /// @brief Construct generator for specific parent
     /// @param parent "muonium" or "antimuonium" (determines PDG IDs in generated event)
     /// @param momentum Muonium momentum
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
+    /// @param thinningRatio Thinning factor (non-negative, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     M2ENNEGenerator(std::string_view parent, Vector3D momentum,

--- a/src/Mustard/Physics/Generator/M2ENNGGGenerator.c++
+++ b/src/Mustard/Physics/Generator/M2ENNGGGenerator.c++
@@ -32,14 +32,16 @@ namespace Mustard::inline Physics::inline Generator {
 
 using namespace PhysicalConstant;
 
-M2ENNGGGenerator::M2ENNGGGenerator(std::string_view parent, Vector3D momentum, Vector3D polarization, double irCut,
+M2ENNGGGenerator::M2ENNGGGenerator(std::string_view parent, Vector3D momentum, Vector3D polarization,
+                                   double softCutoff, double collinearCutoff,
                                    std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize,
                                    std::optional<double> stepSize) :
     MultipleTryMetropolisGenerator{{}, polarization, {}, {}, std::move(thinningRatio), acfSampleSize.value_or(200000), stepSize.value_or(0.1)} {
     Parent(parent);
     ParentMomentum(momentum);
     Mass({electron_mass_c2, 0, 0, 0, 0});
-    IRCut(irCut);
+    SoftCutoff(softCutoff);
+    CollinearCutoff(collinearCutoff);
     AddIdenticalSet({3, 4});
 }
 
@@ -58,9 +60,14 @@ auto M2ENNGGGenerator::ParentMomentum(Vector3D momentum) -> void {
     ISMomenta({energy, momentum});
 }
 
-auto M2ENNGGGenerator::IRCut(double irCut) -> void {
-    MultipleTryMetropolisGenerator::IRCut(3, irCut);
-    MultipleTryMetropolisGenerator::IRCut(4, irCut);
+auto M2ENNGGGenerator::SoftCutoff(double softCutoff) -> void {
+    MultipleTryMetropolisGenerator::SoftCutoff(3, softCutoff);
+    MultipleTryMetropolisGenerator::SoftCutoff(4, softCutoff);
+}
+
+auto M2ENNGGGenerator::CollinearCutoff(double collinearCutoff) -> void {
+    MultipleTryMetropolisGenerator::CollinearCutoff({0, 3}, collinearCutoff);
+    MultipleTryMetropolisGenerator::CollinearCutoff({0, 4}, collinearCutoff);
 }
 
 } // namespace Mustard::inline Physics::inline Generator

--- a/src/Mustard/Physics/Generator/M2ENNGGGenerator.c++
+++ b/src/Mustard/Physics/Generator/M2ENNGGGenerator.c++
@@ -38,7 +38,7 @@ M2ENNGGGenerator::M2ENNGGGenerator(std::string_view parent, Vector3D momentum, V
                                    std::optional<double> stepSize) :
     MultipleTryMetropolisGenerator{{}, polarization, {}, {}, std::move(thinningRatio), acfSampleSize.value_or(200000), stepSize.value_or(0.1)} {
     Parent(parent);
-    ParentMomentum(momentum);
+    Momentum(momentum);
     Mass({electron_mass_c2, 0, 0, 0, 0});
     SoftCutoff(softCutoff);
     CollinearCutoff(collinearCutoff);
@@ -55,9 +55,9 @@ auto M2ENNGGGenerator::Parent(std::string_view parent) -> void {
     }
 }
 
-auto M2ENNGGGenerator::ParentMomentum(Vector3D momentum) -> void {
+auto M2ENNGGGenerator::Momentum(Vector3D momentum) -> void {
     const auto energy{std::sqrt(momentum.mag2() + muc::pow(muon_mass_c2, 2))};
-    ISMomenta({energy, momentum});
+    Momenta({energy, momentum});
 }
 
 auto M2ENNGGGenerator::SoftCutoff(double softCutoff) -> void {

--- a/src/Mustard/Physics/Generator/M2ENNGGGenerator.h++
+++ b/src/Mustard/Physics/Generator/M2ENNGGGenerator.h++
@@ -37,11 +37,13 @@ public:
     /// @param parent "mu-" or "mu+" (determines PDG IDs in generated event)
     /// @param momentum Muon momentum
     /// @param polarization Muon polarization vector
-    /// @param irCut IR cut for final-state photons
+    /// @param softCutoff Low-energy cutoff for final-state photons (in the c.m. frame)
+    /// @param collinearCutoff Collinear cutoff on angles between final-state photons and e⁺/e⁻ (in the c.m. frame)
     /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
-    M2ENNGGGenerator(std::string_view parent, Vector3D momentum, Vector3D polarization, double irCut,
+    M2ENNGGGenerator(std::string_view parent, Vector3D momentum, Vector3D polarization,
+                     double softCutoff, double collinearCutoff,
                      std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {},
                      std::optional<double> stepSize = {});
 
@@ -52,9 +54,12 @@ public:
     /// @brief Set parent momentum
     /// @param momentum Muon momentum
     auto ParentMomentum(Vector3D momentum) -> void;
-    /// @brief Set IR cut for final-state photons
-    /// @param irCut IR cut for final-state photons
-    auto IRCut(double irCut) -> void;
+    /// @brief Set soft cutoff for final-state photons
+    /// @param softCutoff Low-energy cutoff for final-state photons (in the c.m. frame)
+    auto SoftCutoff(double softCutoff) -> void;
+    /// @brief Set collinear cutoff for final-state photons
+    /// @param collinearCutoff Cutoff on angles between final-state photons and e⁺/e⁻ (in the c.m. frame)
+    auto CollinearCutoff(double collinearCutoff) -> void;
 };
 
 } // namespace Mustard::inline Physics::inline Generator

--- a/src/Mustard/Physics/Generator/M2ENNGGGenerator.h++
+++ b/src/Mustard/Physics/Generator/M2ENNGGGenerator.h++
@@ -53,7 +53,7 @@ public:
     auto Parent(std::string_view parent) -> void;
     /// @brief Set parent momentum
     /// @param momentum Muon momentum
-    auto ParentMomentum(Vector3D momentum) -> void;
+    auto Momentum(Vector3D momentum) -> void;
     /// @brief Set soft cutoff for final-state photons
     /// @param softCutoff Low-energy cutoff for final-state photons (in the c.m. frame)
     auto SoftCutoff(double softCutoff) -> void;

--- a/src/Mustard/Physics/Generator/M2ENNGGGenerator.h++
+++ b/src/Mustard/Physics/Generator/M2ENNGGGenerator.h++
@@ -39,7 +39,7 @@ public:
     /// @param polarization Muon polarization vector
     /// @param softCutoff Low-energy cutoff for final-state photons (in the c.m. frame)
     /// @param collinearCutoff Collinear cutoff on angles between final-state photons and e⁺/e⁻ (in the c.m. frame)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
+    /// @param thinningRatio Thinning factor (non-negative, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     M2ENNGGGenerator(std::string_view parent, Vector3D momentum, Vector3D polarization,

--- a/src/Mustard/Physics/Generator/M2ENNGGenerator.c++
+++ b/src/Mustard/Physics/Generator/M2ENNGGenerator.c++
@@ -1,0 +1,70 @@
+// -*- C++ -*-
+//
+// Copyright (C) 2020-2025  Mustard developers
+//
+// This file is part of Mustard, an offline software framework for HEP experiments.
+//
+// Mustard is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// Mustard is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Mustard. If not, see <https://www.gnu.org/licenses/>.
+
+#include "Mustard/IO/PrettyLog.h++"
+#include "Mustard/Physics/Generator/M2ENNGGenerator.h++"
+#include "Mustard/Utility/PhysicalConstant.h++"
+
+#include "muc/math"
+
+#include "fmt/core.h"
+
+#include <cmath>
+#include <stdexcept>
+#include <utility>
+
+namespace Mustard::inline Physics::inline Generator {
+
+using namespace PhysicalConstant;
+
+M2ENNGGenerator::M2ENNGGenerator(std::string_view parent, Vector3D momentum, Vector3D polarization,
+                                   double softCutoff, double collinearCutoff,
+                                   std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize,
+                                   std::optional<double> stepSize) :
+    MultipleTryMetropolisGenerator{{}, polarization, {}, {}, std::move(thinningRatio), acfSampleSize.value_or(100000), stepSize.value_or(0.1)} {
+    Parent(parent);
+    Momentum(momentum);
+    Mass({electron_mass_c2, 0, 0, 0});
+    SoftCutoff(softCutoff);
+    CollinearCutoff(collinearCutoff);
+}
+
+auto M2ENNGGenerator::Parent(std::string_view parent) -> void {
+    if (parent == "mu-") {
+        PDGID({11, -12, 14, 22});
+    } else if (parent == "mu+") {
+        PDGID({-11, 12, -14, 22});
+    } else {
+        Throw<std::invalid_argument>(fmt::format("Parent should be mu- or mu+, got '{}'", parent));
+    }
+}
+
+auto M2ENNGGenerator::Momentum(Vector3D momentum) -> void {
+    const auto energy{std::sqrt(momentum.mag2() + muc::pow(muon_mass_c2, 2))};
+    Momenta({energy, momentum});
+}
+
+auto M2ENNGGenerator::SoftCutoff(double softCutoff) -> void {
+    MultipleTryMetropolisGenerator::SoftCutoff(3, softCutoff);
+}
+
+auto M2ENNGGenerator::CollinearCutoff(double collinearCutoff) -> void {
+    MultipleTryMetropolisGenerator::CollinearCutoff({0, 3}, collinearCutoff);
+}
+
+} // namespace Mustard::inline Physics::inline Generator

--- a/src/Mustard/Physics/Generator/M2ENNGGenerator.h++
+++ b/src/Mustard/Physics/Generator/M2ENNGGenerator.h++
@@ -39,7 +39,7 @@ public:
     /// @param polarization Muon polarization vector
     /// @param softCutoff Low-energy cutoff for final-state photon (in the c.m. frame)
     /// @param collinearCutoff Collinear cutoff on angles between final-state photon and e⁺/e⁻ (in the c.m. frame)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
+    /// @param thinningRatio Thinning factor (non-negative, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     M2ENNGGenerator(std::string_view parent, Vector3D momentum, Vector3D polarization,

--- a/src/Mustard/Physics/Generator/M2ENNGGenerator.h++
+++ b/src/Mustard/Physics/Generator/M2ENNGGenerator.h++
@@ -37,8 +37,8 @@ public:
     /// @param parent "mu-" or "mu+" (determines PDG IDs in generated event)
     /// @param momentum Muon momentum
     /// @param polarization Muon polarization vector
-    /// @param softCutoff Low-energy cutoff for final-state photons (in the c.m. frame)
-    /// @param collinearCutoff Collinear cutoff on angles between final-state photons and e⁺/e⁻ (in the c.m. frame)
+    /// @param softCutoff Low-energy cutoff for final-state photon (in the c.m. frame)
+    /// @param collinearCutoff Collinear cutoff on angles between final-state photon and e⁺/e⁻ (in the c.m. frame)
     /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
@@ -54,11 +54,11 @@ public:
     /// @brief Set parent momentum
     /// @param momentum Muon momentum
     auto Momentum(Vector3D momentum) -> void;
-    /// @brief Set soft cutoff for final-state photons
-    /// @param softCutoff Low-energy cutoff for final-state photons (in the c.m. frame)
+    /// @brief Set soft cutoff for final-state photon
+    /// @param softCutoff Low-energy cutoff for final-state photon (in the c.m. frame)
     auto SoftCutoff(double softCutoff) -> void;
-    /// @brief Set collinear cutoff for final-state photons
-    /// @param collinearCutoff Cutoff on angles between final-state photons and e⁺/e⁻ (in the c.m. frame)
+    /// @brief Set collinear cutoff for final-state photon
+    /// @param collinearCutoff Cutoff on angles between final-state photon and e⁺/e⁻ (in the c.m. frame)
     auto CollinearCutoff(double collinearCutoff) -> void;
 };
 

--- a/src/Mustard/Physics/Generator/M2ENNGGenerator.h++
+++ b/src/Mustard/Physics/Generator/M2ENNGGenerator.h++
@@ -1,0 +1,65 @@
+// -*- C++ -*-
+//
+// Copyright (C) 2020-2025  Mustard developers
+//
+// This file is part of Mustard, an offline software framework for HEP experiments.
+//
+// Mustard is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// Mustard is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Mustard. If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "Mustard/Math/Vector.h++"
+#include "Mustard/Physics/Generator/MultipleTryMetropolisGenerator.h++"
+#include "Mustard/Physics/QFT/MSqM2ENNG.h++"
+
+#include <optional>
+#include <string_view>
+
+namespace Mustard::inline Physics::inline Generator {
+
+/// @class M2ENNGGenerator
+/// @brief MCMC generator for mu->enng decays
+/// Kinematics: μ⁻ → e⁻ ν ν γ
+///             μ⁺ → e⁺ ν ν γ
+class M2ENNGGenerator : public MultipleTryMetropolisGenerator<1, 4, QFT::MSqM2ENNG> {
+public:
+    /// @brief Construct generator for specific parent
+    /// @param parent "mu-" or "mu+" (determines PDG IDs in generated event)
+    /// @param momentum Muon momentum
+    /// @param polarization Muon polarization vector
+    /// @param softCutoff Low-energy cutoff for final-state photons (in the c.m. frame)
+    /// @param collinearCutoff Collinear cutoff on angles between final-state photons and e⁺/e⁻ (in the c.m. frame)
+    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
+    /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
+    /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
+    M2ENNGGenerator(std::string_view parent, Vector3D momentum, Vector3D polarization,
+                     double softCutoff, double collinearCutoff,
+                     std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {},
+                     std::optional<double> stepSize = {});
+
+    /// @brief Set parent particle
+    /// @param parent "mu-" or "mu+"
+    /// @exception std::invalid_argument for invalid parent names
+    auto Parent(std::string_view parent) -> void;
+    /// @brief Set parent momentum
+    /// @param momentum Muon momentum
+    auto Momentum(Vector3D momentum) -> void;
+    /// @brief Set soft cutoff for final-state photons
+    /// @param softCutoff Low-energy cutoff for final-state photons (in the c.m. frame)
+    auto SoftCutoff(double softCutoff) -> void;
+    /// @brief Set collinear cutoff for final-state photons
+    /// @param collinearCutoff Cutoff on angles between final-state photons and e⁺/e⁻ (in the c.m. frame)
+    auto CollinearCutoff(double collinearCutoff) -> void;
+};
+
+} // namespace Mustard::inline Physics::inline Generator

--- a/src/Mustard/Physics/Generator/MCMCGenerator.h++
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.h++
@@ -118,61 +118,37 @@ public:
                   std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {});
     /// @brief Construct event generator
     /// @param pI initial-state 4-momenta
-    /// @param polarization Initial-state polarization vector
+    /// @param polarization Initial-state polarization vector(s)
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
     /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @note This overload is only enabled for polarized decay
-    MCMCGenerator(const InitialStateMomenta& pI, Vector3D polarization,
+    MCMCGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                   const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                   std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {})
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
-    /// @brief Construct event generator
-    /// @param pI initial-state 4-momenta
-    /// @param polarization Initial-state polarization vectors
-    /// @param pdgID Array of particle PDG IDs (index order preserved)
-    /// @param mass Array of particle masses (index order preserved)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
-    /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
-    /// @note This overload is only enabled for polarized scattering
-    MCMCGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
-                  const std::array<int, N>& pdgID, const std::array<double, N>& mass,
-                  std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {})
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
-    /// @brief Get polarization vector
-    /// @note This overload is only enabled for polarized decay
-    auto InitialStatePolarization() const -> Vector3D
+    /// @brief Get initial-state polarization vector(s)
+    /// @note This overload is only enabled for polarized process
+    auto ISPolarization() const -> const typename A::InitialStatePolarization&
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
-    /// @brief Get polarization vector
+    /// @brief Get initial-state polarization vector
     /// @param i Particle index (0 ≤ i < M)
     /// @note This overload is only enabled for polarized scattering
-    auto InitialStatePolarization(int i) const -> Vector3D
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
-    /// @brief Get all polarization vectors
-    /// @note This overload is only enabled for polarized scattering
-    auto InitialStatePolarization() const -> const std::array<Vector3D, M>&
+    auto ISPolarization(int i) const -> Vector3D
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
-    /// @brief Set polarization vector
-    /// @param pol Polarization vector (|pol| ≤ 1)
-    /// @note This overload is only enabled for polarized decay
-    /// @warning The Markov chain requires reinitialize if value changes
-    auto InitialStatePolarization(Vector3D pol) -> void
+    /// @brief Set initial-state polarization vector(s)
+    /// @param pol Polarization vector(s) (all |pol| ≤ 1)
+    /// @note This overload is only enabled for polarized process
+    auto ISPolarization(const typename A::InitialStatePolarization& pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
-    /// @brief Set polarization for single initial particle
+    /// @brief Set polarization for single initial-state particle
     /// @param i Particle index (0 ≤ i < M)
     /// @param pol Polarization vector (|pol| ≤ 1)
     /// @note This overload is only enabled for polarized scattering
-    /// @warning The Markov chain requires reinitialize if value changes
-    auto InitialStatePolarization(int i, Vector3D pol) -> void
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
-    /// @brief Set all polarization vectors
-    /// @param pol Array of polarization vectors for each initial particle (all |pol| ≤ 1)
-    /// @note This overload is only enabled for polarized scattering
-    /// @warning The Markov chain requires reinitialize if value changes
-    auto InitialStatePolarization(const std::array<Vector3D, M>& pol) -> void
+    auto ISPolarization(int i, Vector3D pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
     /// @brief Set user-defined acceptance function in PDF (PDF = |M|² × acceptance)

--- a/src/Mustard/Physics/Generator/MCMCGenerator.h++
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.h++
@@ -177,7 +177,7 @@ public:
     /// @param rng Reference to CLHEP random engine
     /// @return Generated event
     /// @warning Initial-state momenta passed to this function are ignored.
-    /// Use `ISMomenta` to set initial-state momenta
+    /// Use `Momenta` to set initial-state momenta
     virtual auto operator()(CLHEP::HepRandomEngine& rng, InitialStateMomenta) -> Event override;
     // Avoid hiding other operator() overloads from base class
     using Base::operator();

--- a/src/Mustard/Physics/Generator/MCMCGenerator.h++
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.h++
@@ -131,24 +131,24 @@ public:
 
     /// @brief Get initial-state polarization vector(s)
     /// @note This overload is only enabled for polarized process
-    auto ISPolarization() const -> const typename A::InitialStatePolarization&
+    auto Polarization() const -> const typename A::InitialStatePolarization&
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
     /// @brief Get initial-state polarization vector
     /// @param i Particle index (0 ≤ i < M)
     /// @note This overload is only enabled for polarized scattering
-    auto ISPolarization(int i) const -> Vector3D
+    auto Polarization(int i) const -> Vector3D
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
     /// @brief Set initial-state polarization vector(s)
     /// @param pol Polarization vector(s) (all |pol| ≤ 1)
     /// @note This overload is only enabled for polarized process
-    auto ISPolarization(const typename A::InitialStatePolarization& pol) -> void
+    auto Polarization(const typename A::InitialStatePolarization& pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
     /// @brief Set polarization for single initial-state particle
     /// @param i Particle index (0 ≤ i < M)
     /// @param pol Polarization vector (|pol| ≤ 1)
     /// @note This overload is only enabled for polarized scattering
-    auto ISPolarization(int i, Vector3D pol) -> void
+    auto Polarization(int i, Vector3D pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
     /// @brief Set user-defined acceptance function in PDF (PDF = |M|² × acceptance)
@@ -186,7 +186,7 @@ protected:
     /// @brief Set initial-state 4-momenta
     /// @param pI initial-state 4-momenta
     /// @warning The Markov chain requires reinitialize if value changes
-    auto ISMomenta(const InitialStateMomenta& pI) -> void;
+    auto Momenta(const InitialStateMomenta& pI) -> void;
     /// @brief Set final-state masses
     /// @param mass Array of particle masses
     /// @warning The Markov chain requires reinitialize if value changes

--- a/src/Mustard/Physics/Generator/MCMCGenerator.h++
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.h++
@@ -97,7 +97,7 @@ protected:
         static constexpr int dim{std::tuple_size_v<RandomState>};
         struct State {
             RandomState u;          ///< Random state
-            std::array<int, N> pID; ///< Particle ID mapping (for swapping identical particles)
+            std::array<int, N> pID; ///< Particle ID permutation (for swapping identical particles, if any)
         } state;                    ///< State of the chain
         double mSqAcceptanceDetJ;   ///< |M|² × acceptance × |J|
         Event event;                ///< The corresponding event
@@ -178,7 +178,7 @@ public:
     /// @brief Set user-defined acceptance function in PDF (PDF = |M|² × acceptance)
     /// @param Acceptance User-defined acceptance
     /// @warning The Markov chain requires reinitialize after set
-    auto Acceptance(AcceptanceFunction Acceptance) -> void;
+    auto Acceptance(AcceptanceFunction acceptance) -> void;
 
     /// @brief Set thinning ratio
     /// Larger the thinning ratio, more samples will be discarded,
@@ -203,7 +203,7 @@ public:
     /// @warning Initial-state momenta passed to this function are ignored.
     /// Use `ISMomenta` to set initial-state momenta
     virtual auto operator()(CLHEP::HepRandomEngine& rng, InitialStateMomenta) -> Event override;
-    // Inherit operator() overloads
+    // Avoid hiding other operator() overloads from base class
     using Base::operator();
 
 protected:
@@ -215,14 +215,22 @@ protected:
     /// @param mass Array of particle masses
     /// @warning The Markov chain requires reinitialize if value changes
     auto Mass(const std::array<double, N>& mass) -> void;
-    /// @brief Set IR cuts for single final-state particle
+
+    /// @brief Set low-energy cutoff for single final-state particle to avoid infrared divergence (if applicable)
     /// @param i Particle index (0 ≤ i < N)
-    /// @param cut IR cut value
+    /// @param cutoff Soft cutoff value (on kinetic energy in the c.m. frame)
     /// @warning The Markov chain requires reinitialize after set
-    auto IRCut(int i, double cut) -> void;
+    auto SoftCutoff(int i, double cutoff) -> void;
+    /// @brief Set collinear cutoff for two particles to avoid infrared divergence (if applicable)
+    /// @param pID Pair of particle indices (0 ≤ index < N)
+    /// @param cutoff Collinear cutoff value (on angle between the two particles in the c.m. frame)
+    auto CollinearCutoff(std::pair<int, int> pID, double cutoff) -> void;
+
+    // Avoid hiding other Acceptance overloads from base class
+    using Base::Acceptance;
 
     /// @brief Notify MCMC that reinitialize is required
-    auto MCMCInitializeRequired() -> void;
+    auto MCMCInitializationRequired() -> void;
 
     /// @brief Transform hypercube to phase space
     /// @param u A random state

--- a/src/Mustard/Physics/Generator/MCMCGenerator.h++
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.h++
@@ -112,7 +112,7 @@ public:
     /// @param pI initial-state 4-momenta
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
+    /// @param thinningRatio Thinning factor (non-negative, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     MCMCGenerator(const InitialStateMomenta& pI, const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                   std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {});
@@ -121,7 +121,7 @@ public:
     /// @param polarization Initial-state polarization vector(s)
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
+    /// @param thinningRatio Thinning factor (non-negative, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @note This overload is only enabled for polarized decay
     MCMCGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,

--- a/src/Mustard/Physics/Generator/MCMCGenerator.h++
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.h++
@@ -127,12 +127,12 @@ public:
     MCMCGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                   const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                   std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {})
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
+        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>>;
 
     /// @brief Get initial-state polarization vector(s)
     /// @note This overload is only enabled for polarized process
     auto Polarization() const -> const typename A::InitialStatePolarization&
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
+        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>>;
     /// @brief Get initial-state polarization vector
     /// @param i Particle index (0 ≤ i < M)
     /// @note This overload is only enabled for polarized scattering
@@ -143,7 +143,7 @@ public:
     /// @param pol Polarization vector(s) (all |pol| ≤ 1)
     /// @note This overload is only enabled for polarized process
     auto Polarization(const typename A::InitialStatePolarization& pol) -> void
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
+        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>>;
     /// @brief Set polarization for single initial-state particle
     /// @param i Particle index (0 ≤ i < M)
     /// @param pol Polarization vector (|pol| ≤ 1)

--- a/src/Mustard/Physics/Generator/MCMCGenerator.inl
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.inl
@@ -75,7 +75,7 @@ template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MCMCGenerator<M, N, A>::InitialStatePolarization(Vector3D pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
     if (not pol.isNear(InitialStatePolarization(), muc::default_rel_tol<double>)) {
-        MCMCInitializeRequired();
+        MCMCInitializationRequired();
     }
     Base::InitialStatePolarization(pol);
 }
@@ -84,7 +84,7 @@ template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MCMCGenerator<M, N, A>::InitialStatePolarization(int i, Vector3D pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
     if (not pol.isNear(InitialStatePolarization(i), muc::default_rel_tol<double>)) {
-        MCMCInitializeRequired();
+        MCMCInitializationRequired();
     }
     Base::InitialStatePolarization(i, pol);
 }
@@ -94,15 +94,15 @@ auto MCMCGenerator<M, N, A>::InitialStatePolarization(const std::array<Vector3D,
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
     if (not std::ranges::equal(pol, InitialStatePolarization(),
                                [](auto&& a, auto&& b) { return a.isNear(b, muc::default_rel_tol<double>); })) {
-        MCMCInitializeRequired();
+        MCMCInitializationRequired();
     }
     Base::InitialStatePolarization(pol);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MCMCGenerator<M, N, A>::Acceptance(AcceptanceFunction Acceptance) -> void {
+    MCMCInitializationRequired();
     Base::Acceptance(Acceptance);
-    MCMCInitializeRequired();
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
@@ -147,14 +147,11 @@ auto MCMCGenerator<M, N, A>::MCMCInitialize(CLHEP::HepRandomEngine& rng) -> Auto
     while (true) {
         rng.flatArray(fMC.state.u.size(), fMC.state.u.data());
         auto [event, detJ]{DirectPhaseSpace(fMC.state.u)};
-        if (not this->IRSafe(event.p)) {
+        if (not this->InfraredSafe(event.p)) {
             continue;
         }
-        const auto acceptance{this->ValidAcceptance(event.p)};
-        if (acceptance <= std::numeric_limits<double>::min()) {
-            continue;
-        }
-        const auto mSqAcceptanceDetJ{this->ValidMSqAcceptanceDetJ(event.p, acceptance, detJ)};
+        const auto acceptance{this->Acceptance(event.p)};
+        const auto mSqAcceptanceDetJ{this->MSqAcceptanceDetJ(event.p, acceptance, detJ)};
         if (mSqAcceptanceDetJ <= std::numeric_limits<double>::min()) {
             continue;
         }
@@ -182,11 +179,11 @@ auto MCMCGenerator<M, N, A>::MCMCInitialize(CLHEP::HepRandomEngine& rng) -> Auto
             Eigen::Vector<double, MarkovChain::dim> u;
             rng.flatArray(u.size(), u.data());
             auto [event, detJ]{DirectPhaseSpace(VectorCast<RandomState>(u))};
-            if (not this->IRSafe(event.p)) {
+            if (not this->InfraredSafe(event.p)) {
                 continue;
             }
-            const auto acceptance{this->ValidAcceptance(event.p)};
-            const auto mSqAcceptanceDetJ{this->ValidMSqAcceptanceDetJ(event.p, acceptance, detJ)};
+            const auto acceptance{this->Acceptance(event.p)};
+            const auto mSqAcceptanceDetJ{this->MSqAcceptanceDetJ(event.p, acceptance, detJ)};
             const auto uMSqAcceptanceDetJ{(mSqAcceptanceDetJ * u).eval()};
             mean.u += uMSqAcceptanceDetJ;
             mean.uuT += uMSqAcceptanceDetJ * u.transpose();
@@ -195,7 +192,8 @@ auto MCMCGenerator<M, N, A>::MCMCInitialize(CLHEP::HepRandomEngine& rng) -> Auto
         mean.u /= sumMSqAcceptanceDetJ;
         mean.uuT /= sumMSqAcceptanceDetJ;
         const auto covariance{(mean.uuT - mean.u * mean.u.transpose()).eval()};
-        const auto sqrtDiagCov{Eigen::SelfAdjointEigenSolver<decltype(covariance)>{covariance}.eigenvalues().array().sqrt()};
+        const Eigen::SelfAdjointEigenSolver<decltype(covariance)> covEigenSolver{covariance};
+        const auto sqrtDiagCov{covEigenSolver.eigenvalues().array().sqrt()};
         PrintInfo(fmt::format("Sqrt(diag(covariance)): {}", sqrtDiagCov));
     }
 
@@ -256,7 +254,9 @@ auto MCMCGenerator<M, N, A>::MCMCInitialize(CLHEP::HepRandomEngine& rng) -> Auto
         lastAutocorrelation = &autocorrelation;
     }
     if (not std::ranges::all_of(autocorrelationConverged, [](auto c) { return c; })) {
-        PrintWarning(fmt::format("Autocorrelation not converged. Try increasing ACF sample size (current: {})", fACFSampleSize));
+        PrintWarning(fmt::format("Autocorrelation not converged. Try increasing ACF sample size (current: {}). "
+                                 "Generated events may be highly correlated.",
+                                 fACFSampleSize));
     }
 
     double meanSumAutocorrelation{};
@@ -304,12 +304,12 @@ template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MCMCGenerator<M, N, A>::ISMomenta(const InitialStateMomenta& pI) -> void {
     if constexpr (M == 1) {
         if (not pI.isNear(Base::ISMomenta(), muc::default_rel_tol<double>)) {
-            MCMCInitializeRequired();
+            MCMCInitializationRequired();
         }
     } else {
         if (not std::ranges::equal(pI, Base::ISMomenta(),
                                    [](auto p, auto q) { return p.isNear(q, muc::default_rel_tol<double>); })) {
-            MCMCInitializeRequired();
+            MCMCInitializationRequired();
         }
     }
     Base::ISMomenta(pI);
@@ -319,19 +319,25 @@ template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MCMCGenerator<M, N, A>::Mass(const std::array<double, N>& mass) -> void {
     if (not std::ranges::equal(mass, this->fGENBOD.Mass(),
                                [](auto a, auto b) { return muc::isclose(a, b); })) {
-        MCMCInitializeRequired();
+        MCMCInitializationRequired();
     }
     Base::Mass(mass);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::IRCut(int i, double cut) -> void {
-    MCMCInitializeRequired();
-    Base::IRCut(i, cut);
+auto MCMCGenerator<M, N, A>::SoftCutoff(int i, double cutoff) -> void {
+    MCMCInitializationRequired();
+    Base::SoftCutoff(i, cutoff);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::MCMCInitializeRequired() -> void {
+auto MCMCGenerator<M, N, A>::CollinearCutoff(std::pair<int, int> pID, double cutoff) -> void {
+    MCMCInitializationRequired();
+    Base::CollinearCutoff(pID, cutoff);
+}
+
+template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
+auto MCMCGenerator<M, N, A>::MCMCInitializationRequired() -> void {
     fMCMCInitialized = false;
     fThinningSize = 0;
 }

--- a/src/Mustard/Physics/Generator/MCMCGenerator.inl
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.inl
@@ -90,14 +90,15 @@ auto MCMCGenerator<M, N, A>::Acceptance(AcceptanceFunction Acceptance) -> void {
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MCMCGenerator<M, N, A>::ThinningRatio(double value) -> void {
     if (not std::isfinite(value)) [[unlikely]] {
-        PrintError(fmt::format("Infinite thinning factor (got {})", value));
+        PrintError(fmt::format("Infinite thinning ratio not allowed (got {}), not setting it", value));
+        return;
     }
     if (value < 0) [[unlikely]] {
-        PrintWarning(fmt::format("Negative thinning factor (got {}), setting to 0", value));
-        value = 0;
+        PrintError(fmt::format("Negative thinning ratio not allowed (got {}), not setting it", value));
+        return;
     }
     if (value > 10) [[unlikely]] {
-        PrintWarning(fmt::format("Suspicious thinning factor (got {})", value));
+        PrintWarning(fmt::format("Suspicious thinning ratio (got {})", value));
     }
     fThinningRatio = value;
 }
@@ -105,7 +106,7 @@ auto MCMCGenerator<M, N, A>::ThinningRatio(double value) -> void {
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MCMCGenerator<M, N, A>::ACFSampleSize(unsigned n) -> void {
     if (n == 0) {
-        PrintError("Zero ACF sample size not allowed");
+        PrintError("Zero ACF sample size not allowed, not setting it");
         return;
     }
     if (n <= 10 or std::numeric_limits<int>::max() <= n) [[unlikely]] {
@@ -130,7 +131,16 @@ auto MCMCGenerator<M, N, A>::MCMCInitialize(CLHEP::HepRandomEngine& rng) -> Auto
     // find phase space
     MasterPrintLn("Finding phase space...");
     muc::ranges::iota(fMC.state.pID, 0);
-    while (true) {
+    for (long long counter{};; ++counter) {
+        if (counter >= 1'000'000'000) {
+            const auto billion{std::div(counter, 1'000'000'000ll)};
+            if (billion.rem == 0) [[unlikely]] {
+                PrintWarning(fmt::format("Tried {} billion times to find phase space in {} initialization, still trying...", billion.quot, thisName));
+            }
+            if (billion.quot == 1000) {
+                Throw<std::runtime_error>(fmt::format("Failed to find phase space after 1 trillion tries in {} initialization", thisName));
+            }
+        }
         rng.flatArray(fMC.state.u.size(), fMC.state.u.data());
         auto [event, detJ]{DirectPhaseSpace(fMC.state.u)};
         if (not this->InfraredSafe(event.p)) {

--- a/src/Mustard/Physics/Generator/MCMCGenerator.inl
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.inl
@@ -104,7 +104,11 @@ auto MCMCGenerator<M, N, A>::ThinningRatio(double value) -> void {
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MCMCGenerator<M, N, A>::ACFSampleSize(unsigned n) -> void {
-    if (n >= std::numeric_limits<int>::max()) [[unlikely]] {
+    if (n == 0) {
+        PrintError("Zero ACF sample size not allowed");
+        return;
+    }
+    if (n <= 10 or std::numeric_limits<int>::max() <= n) [[unlikely]] {
         PrintWarning(fmt::format("Suspicious ACF sample size (got {})", n));
     }
     fACFSampleSize = n;

--- a/src/Mustard/Physics/Generator/MCMCGenerator.inl
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.inl
@@ -41,44 +41,44 @@ MCMCGenerator<M, N, A>::MCMCGenerator(const InitialStateMomenta& pI, const typen
                                       std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize) // clang-format off
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> : // clang-format on
     MCMCGenerator{pI, pdgID, mass, std::move(thinningRatio), std::move(acfSampleSize)} {
-    this->ISPolarization(polarization);
+    this->Polarization(polarization);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::ISPolarization() const -> const typename A::InitialStatePolarization&
+auto MCMCGenerator<M, N, A>::Polarization() const -> const typename A::InitialStatePolarization&
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
-    return Base::ISPolarization();
+    return Base::Polarization();
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::ISPolarization(int i) const -> Vector3D
+auto MCMCGenerator<M, N, A>::Polarization(int i) const -> Vector3D
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
-    return Base::ISPolarization(i);
+    return Base::Polarization(i);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::ISPolarization(const typename A::InitialStatePolarization& pol) -> void
+auto MCMCGenerator<M, N, A>::Polarization(const typename A::InitialStatePolarization& pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
     if constexpr (M == 1) {
-        if (not pol.isNear(ISPolarization(), muc::default_rel_tol<double>)) {
+        if (not pol.isNear(Polarization(), muc::default_rel_tol<double>)) {
             MCMCInitializationRequired();
         }
     } else {
-        if (not std::ranges::equal(pol, ISPolarization(),
+        if (not std::ranges::equal(pol, Polarization(),
                                    [](auto&& a, auto&& b) { return a.isNear(b, muc::default_rel_tol<double>); })) {
             MCMCInitializationRequired();
         }
     }
-    Base::ISPolarization(pol);
+    Base::Polarization(pol);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::ISPolarization(int i, Vector3D pol) -> void
+auto MCMCGenerator<M, N, A>::Polarization(int i, Vector3D pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
-    if (not pol.isNear(ISPolarization(i), muc::default_rel_tol<double>)) {
+    if (not pol.isNear(Polarization(i), muc::default_rel_tol<double>)) {
         MCMCInitializationRequired();
     }
-    Base::ISPolarization(i, pol);
+    Base::Polarization(i, pol);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
@@ -283,18 +283,18 @@ auto MCMCGenerator<M, N, A>::operator()(CLHEP::HepRandomEngine& rng, InitialStat
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::ISMomenta(const InitialStateMomenta& pI) -> void {
+auto MCMCGenerator<M, N, A>::Momenta(const InitialStateMomenta& pI) -> void {
     if constexpr (M == 1) {
-        if (not pI.isNear(Base::ISMomenta(), muc::default_rel_tol<double>)) {
+        if (not pI.isNear(Base::Momenta(), muc::default_rel_tol<double>)) {
             MCMCInitializationRequired();
         }
     } else {
-        if (not std::ranges::equal(pI, Base::ISMomenta(),
+        if (not std::ranges::equal(pI, Base::Momenta(),
                                    [](auto p, auto q) { return p.isNear(q, muc::default_rel_tol<double>); })) {
             MCMCInitializationRequired();
         }
     }
-    Base::ISMomenta(pI);
+    Base::Momenta(pI);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
@@ -326,7 +326,7 @@ auto MCMCGenerator<M, N, A>::MCMCInitializationRequired() -> void {
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MCMCGenerator<M, N, A>::DirectPhaseSpace(const RandomState& u) -> std::pair<Event, double> {
-    auto event{this->fGENBOD(u, Base::ISMomenta())};
+    auto event{this->fGENBOD(u, Base::Momenta())};
     auto detJ{event.weight};
     event.weight = 1;
     return {std::move(event), detJ};

--- a/src/Mustard/Physics/Generator/MCMCGenerator.inl
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.inl
@@ -90,7 +90,7 @@ auto MCMCGenerator<M, N, A>::Acceptance(AcceptanceFunction Acceptance) -> void {
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MCMCGenerator<M, N, A>::ThinningRatio(double value) -> void {
     if (not std::isfinite(value)) [[unlikely]] {
-        PrintError(fmt::format("Infinite thinning ratio not allowed (got {}), not setting it", value));
+        PrintError(fmt::format("Non-finite thinning ratio not allowed (got {}), not setting it", value));
         return;
     }
     if (value < 0) [[unlikely]] {

--- a/src/Mustard/Physics/Generator/MCMCGenerator.inl
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.inl
@@ -39,14 +39,14 @@ template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 MCMCGenerator<M, N, A>::MCMCGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                                       const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                       std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize) // clang-format off
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> : // clang-format on
+    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> : // clang-format on
     MCMCGenerator{pI, pdgID, mass, std::move(thinningRatio), std::move(acfSampleSize)} {
     this->Polarization(polarization);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MCMCGenerator<M, N, A>::Polarization() const -> const typename A::InitialStatePolarization&
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
+    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> {
     return Base::Polarization();
 }
 
@@ -58,7 +58,7 @@ auto MCMCGenerator<M, N, A>::Polarization(int i) const -> Vector3D
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MCMCGenerator<M, N, A>::Polarization(const typename A::InitialStatePolarization& pol) -> void
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
+    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> {
     if constexpr (M == 1) {
         if (not pol.isNear(Polarization(), muc::default_rel_tol<double>)) {
             MCMCInitializationRequired();

--- a/src/Mustard/Physics/Generator/MCMCGenerator.inl
+++ b/src/Mustard/Physics/Generator/MCMCGenerator.inl
@@ -36,67 +36,49 @@ MCMCGenerator<M, N, A>::MCMCGenerator(const InitialStateMomenta& pI, const std::
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-MCMCGenerator<M, N, A>::MCMCGenerator(const InitialStateMomenta& pI, Vector3D polarization,
+MCMCGenerator<M, N, A>::MCMCGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                                       const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                       std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize) // clang-format off
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> : // clang-format on
     MCMCGenerator{pI, pdgID, mass, std::move(thinningRatio), std::move(acfSampleSize)} {
-    this->InitialStatePolarization(polarization);
+    this->ISPolarization(polarization);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-MCMCGenerator<M, N, A>::MCMCGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
-                                      const std::array<int, N>& pdgID, const std::array<double, N>& mass,
-                                      std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize) // clang-format off
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) : // clang-format on
-    MCMCGenerator{pI, pdgID, mass, std::move(thinningRatio), std::move(acfSampleSize)} {
-    this->InitialStatePolarization(polarization);
-}
-
-template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::InitialStatePolarization() const -> Vector3D
+auto MCMCGenerator<M, N, A>::ISPolarization() const -> const typename A::InitialStatePolarization&
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
-    return Base::InitialStatePolarization();
+    return Base::ISPolarization();
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::InitialStatePolarization(int i) const -> Vector3D
+auto MCMCGenerator<M, N, A>::ISPolarization(int i) const -> Vector3D
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
-    return Base::InitialStatePolarization(i);
+    return Base::ISPolarization(i);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::InitialStatePolarization() const -> const std::array<Vector3D, M>&
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
-    return Base::InitialStatePolarization();
-}
-
-template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::InitialStatePolarization(Vector3D pol) -> void
+auto MCMCGenerator<M, N, A>::ISPolarization(const typename A::InitialStatePolarization& pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
-    if (not pol.isNear(InitialStatePolarization(), muc::default_rel_tol<double>)) {
-        MCMCInitializationRequired();
+    if constexpr (M == 1) {
+        if (not pol.isNear(ISPolarization(), muc::default_rel_tol<double>)) {
+            MCMCInitializationRequired();
+        }
+    } else {
+        if (not std::ranges::equal(pol, ISPolarization(),
+                                   [](auto&& a, auto&& b) { return a.isNear(b, muc::default_rel_tol<double>); })) {
+            MCMCInitializationRequired();
+        }
     }
-    Base::InitialStatePolarization(pol);
+    Base::ISPolarization(pol);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::InitialStatePolarization(int i, Vector3D pol) -> void
+auto MCMCGenerator<M, N, A>::ISPolarization(int i, Vector3D pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
-    if (not pol.isNear(InitialStatePolarization(i), muc::default_rel_tol<double>)) {
+    if (not pol.isNear(ISPolarization(i), muc::default_rel_tol<double>)) {
         MCMCInitializationRequired();
     }
-    Base::InitialStatePolarization(i, pol);
-}
-
-template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MCMCGenerator<M, N, A>::InitialStatePolarization(const std::array<Vector3D, M>& pol) -> void
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
-    if (not std::ranges::equal(pol, InitialStatePolarization(),
-                               [](auto&& a, auto&& b) { return a.isNear(b, muc::default_rel_tol<double>); })) {
-        MCMCInitializationRequired();
-    }
-    Base::InitialStatePolarization(pol);
+    Base::ISPolarization(i, pol);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
@@ -45,7 +45,7 @@
 
 #include "gsl/gsl"
 
-#include "fmt/core.h"
+#include "fmt/std.h"
 
 #include <algorithm>
 #include <array>
@@ -209,7 +209,7 @@ protected:
     GENBOD<M, N> fGENBOD;                   ///< Phase space generator
 
 private:
-    InitialStateMomenta fMomenta;                                   ///< Initial-state 4-momenta
+    InitialStateMomenta fMomenta;                                     ///< Initial-state 4-momenta
     Vector3D fBoostFromLabToCM;                                       ///< Boost from lab frame to c.m. frame
                                                                       //
     double fFSSymmetryFactor;                                         ///< Final-state identical particle symmetry factor

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
@@ -173,7 +173,7 @@ protected:
     auto SoftCutoff(int i, double cutoff) -> void;
     /// @brief Set collinear cutoff for two particles to avoid infrared divergence (if applicable)
     /// @param pID Pair of particle indices (0 ≤ index < N)
-    /// @param cutoff Collinear cutoff value (on angle between the two particles in the c.m. frame)
+    /// @param cutoff Collinear cutoff value (on angle between the two particles in the c.m. frame, should within (0, π))
     auto CollinearCutoff(std::pair<int, int> pID, double cutoff) -> void;
     /// @brief Check final-state momenta pass the soft cutoff and collinear cutoff (i.e. are IR-safe)
     /// @param pF Final states' 4-momenta

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
@@ -31,6 +31,7 @@
 #include "Mustard/Utility/VectorArithmeticOperator.h++"
 
 #include "CLHEP/Random/Random.h"
+#include "CLHEP/Units/SystemOfUnits.h"
 
 #include "mplr/mplr.hpp"
 
@@ -121,18 +122,6 @@ protected:
     /// @param pI initial-state 4-momenta
     auto ISMomenta(const InitialStateMomenta& pI) -> void;
 
-    /// @brief Set final-state PDG IDs
-    /// @param pdgID Array of particle PDG IDs
-    auto PDGID(const std::array<int, N>& pdgID) -> void { fGENBOD.PDGID(pdgID); }
-    /// @brief Set final-state masses
-    /// @param mass Array of particle masses
-    auto Mass(const std::array<double, N>& mass) -> void { fGENBOD.Mass(mass); }
-
-    /// @brief Generate an event on phase space
-    /// @param rng Reference to CLHEP random engine
-    /// @return An event from phase space
-    auto PhaseSpace(CLHEP::HepRandomEngine& rng) -> auto { return fGENBOD(rng, fISMomenta); }
-
     /// @brief Get initial-state polarization vector(s)
     /// @note This overload is only enabled for polarized process
     auto ISPolarization() const -> const typename A::InitialStatePolarization&
@@ -154,6 +143,18 @@ protected:
     /// @note This overload is only enabled for polarized scattering
     auto ISPolarization(int i, Vector3D pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
+
+    /// @brief Set final-state PDG IDs
+    /// @param pdgID Array of particle PDG IDs
+    auto PDGID(const std::array<int, N>& pdgID) -> void { fGENBOD.PDGID(pdgID); }
+    /// @brief Set final-state masses
+    /// @param mass Array of particle masses
+    auto Mass(const std::array<double, N>& mass) -> void { fGENBOD.Mass(mass); }
+
+    /// @brief Generate an event on phase space
+    /// @param rng Reference to CLHEP random engine
+    /// @return An event from phase space
+    auto PhaseSpace(CLHEP::HepRandomEngine& rng) -> auto { return fGENBOD(rng, fISMomenta); }
 
     /// @brief Add an identical particle index set
     /// @param set A vector of particle indices (0 ≤ index < N)

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
@@ -99,7 +99,7 @@ public:
     /// @param mass Array of particle masses (index order preserved)
     MatrixElementBasedGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                                 const std::array<int, N>& pdgID, const std::array<double, N>& mass)
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
+        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>>;
 
     /// @brief Get currently set initial-state 4-momenta
     auto Momenta() const -> const auto& { return fMomenta; }
@@ -125,7 +125,7 @@ protected:
     /// @brief Get initial-state polarization vector(s)
     /// @note This overload is only enabled for polarized process
     auto Polarization() const -> const typename A::InitialStatePolarization&
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
+        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>>;
     /// @brief Get initial-state polarization vector
     /// @param i Particle index (0 ≤ i < M)
     /// @note This overload is only enabled for polarized scattering
@@ -136,7 +136,7 @@ protected:
     /// @param pol Polarization vector(s) (all |pol| ≤ 1)
     /// @note This overload is only enabled for polarized process
     auto Polarization(const typename A::InitialStatePolarization& pol) -> void
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
+        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>>;
     /// @brief Set polarization for single initial-state particle
     /// @param i Particle index (0 ≤ i < M)
     /// @param pol Polarization vector (|pol| ≤ 1)

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
@@ -102,7 +102,7 @@ public:
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
 
     /// @brief Get currently set initial-state 4-momenta
-    auto ISMomenta() const -> const auto& { return fISMomenta; }
+    auto Momenta() const -> const auto& { return fMomenta; }
 
     /// @brief Compute 1/S × |M|² × acceptance integral on phase space by Monte Carlo integration.
     /// Useful for calculating total decay width or cross section
@@ -120,28 +120,28 @@ public:
 protected:
     /// @brief Set initial-state 4-momenta
     /// @param pI initial-state 4-momenta
-    auto ISMomenta(const InitialStateMomenta& pI) -> void;
+    auto Momenta(const InitialStateMomenta& pI) -> void;
 
     /// @brief Get initial-state polarization vector(s)
     /// @note This overload is only enabled for polarized process
-    auto ISPolarization() const -> const typename A::InitialStatePolarization&
+    auto Polarization() const -> const typename A::InitialStatePolarization&
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
     /// @brief Get initial-state polarization vector
     /// @param i Particle index (0 ≤ i < M)
     /// @note This overload is only enabled for polarized scattering
-    auto ISPolarization(int i) const -> Vector3D
+    auto Polarization(int i) const -> Vector3D
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
     /// @brief Set initial-state polarization vector(s)
     /// @param pol Polarization vector(s) (all |pol| ≤ 1)
     /// @note This overload is only enabled for polarized process
-    auto ISPolarization(const typename A::InitialStatePolarization& pol) -> void
+    auto Polarization(const typename A::InitialStatePolarization& pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
     /// @brief Set polarization for single initial-state particle
     /// @param i Particle index (0 ≤ i < M)
     /// @param pol Polarization vector (|pol| ≤ 1)
     /// @note This overload is only enabled for polarized scattering
-    auto ISPolarization(int i, Vector3D pol) -> void
+    auto Polarization(int i, Vector3D pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
     /// @brief Set final-state PDG IDs
@@ -154,7 +154,7 @@ protected:
     /// @brief Generate an event on phase space
     /// @param rng Reference to CLHEP random engine
     /// @return An event from phase space
-    auto PhaseSpace(CLHEP::HepRandomEngine& rng) -> auto { return fGENBOD(rng, fISMomenta); }
+    auto PhaseSpace(CLHEP::HepRandomEngine& rng) -> auto { return fGENBOD(rng, fMomenta); }
 
     /// @brief Add an identical particle index set
     /// @param set A vector of particle indices (0 ≤ index < N)
@@ -209,7 +209,7 @@ protected:
     GENBOD<M, N> fGENBOD;                   ///< Phase space generator
 
 private:
-    InitialStateMomenta fISMomenta;                                   ///< Initial-state 4-momenta
+    InitialStateMomenta fMomenta;                                   ///< Initial-state 4-momenta
     Vector3D fBoostFromLabToCM;                                       ///< Boost from lab frame to c.m. frame
                                                                       //
     double fFSSymmetryFactor;                                         ///< Final-state identical particle symmetry factor

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
@@ -178,7 +178,7 @@ protected:
     /// @brief Check final-state momenta pass the soft cutoff and collinear cutoff (i.e. are IR-safe)
     /// @param pF Final states' 4-momenta
     /// @return true if momenta are IR-safe
-    auto InfraredSafe(FinalStateMomenta pF) const -> bool;
+    auto InfraredSafe(const FinalStateMomenta& pF) const -> bool;
 
     /// @brief Set user-defined acceptance function (normally 0 <= acceptance <= 1)
     /// (PDF = 1/S × |M|² × acceptance, weight = 1 / acceptance)

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
@@ -93,21 +93,12 @@ public:
     MatrixElementBasedGenerator(const InitialStateMomenta& pI, const std::array<int, N>& pdgID, const std::array<double, N>& mass);
     /// @brief Construct event generator
     /// @param pI initial-state 4-momenta
-    /// @param polarization Initial-state polarization vector
+    /// @param polarization Initial-state polarization vector(s)
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
-    MatrixElementBasedGenerator(const InitialStateMomenta& pI, Vector3D polarization,
+    MatrixElementBasedGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                                 const std::array<int, N>& pdgID, const std::array<double, N>& mass)
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
-    /// @brief Construct event generator
-    /// @param pI initial-state 4-momenta
-    /// @param polarization Initial-state polarization vectors
-    /// @param pdgID Array of particle PDG IDs (index order preserved)
-    /// @param mass Array of particle masses (index order preserved)
-    /// @note This overload is only enabled for polarized scattering
-    MatrixElementBasedGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
-                                const std::array<int, N>& pdgID, const std::array<double, N>& mass)
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
     /// @brief Get currently set initial-state 4-momenta
     auto ISMomenta() const -> const auto& { return fISMomenta; }
@@ -142,35 +133,26 @@ protected:
     /// @return An event from phase space
     auto PhaseSpace(CLHEP::HepRandomEngine& rng) -> auto { return fGENBOD(rng, fISMomenta); }
 
-    /// @brief Get polarization vector
-    /// @note This overload is only enabled for polarized decay
-    auto InitialStatePolarization() const -> Vector3D
+    /// @brief Get initial-state polarization vector(s)
+    /// @note This overload is only enabled for polarized process
+    auto ISPolarization() const -> const typename A::InitialStatePolarization&
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
-    /// @brief Get polarization vector
+    /// @brief Get initial-state polarization vector
     /// @param i Particle index (0 ≤ i < M)
     /// @note This overload is only enabled for polarized scattering
-    auto InitialStatePolarization(int i) const -> Vector3D
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
-    /// @brief Get all polarization vectors
-    /// @note This overload is only enabled for polarized scattering
-    auto InitialStatePolarization() const -> const std::array<Vector3D, M>&
+    auto ISPolarization(int i) const -> Vector3D
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
-    /// @brief Set polarization vector
-    /// @param pol Polarization vector (|pol| ≤ 1)
-    /// @note This overload is only enabled for polarized decay
-    auto InitialStatePolarization(Vector3D pol) -> void
+    /// @brief Set initial-state polarization vector(s)
+    /// @param pol Polarization vector(s) (all |pol| ≤ 1)
+    /// @note This overload is only enabled for polarized process
+    auto ISPolarization(const typename A::InitialStatePolarization& pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
-    /// @brief Set polarization for single initial particle
+    /// @brief Set polarization for single initial-state particle
     /// @param i Particle index (0 ≤ i < M)
     /// @param pol Polarization vector (|pol| ≤ 1)
     /// @note This overload is only enabled for polarized scattering
-    auto InitialStatePolarization(int i, Vector3D pol) -> void
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
-    /// @brief Set all polarization vectors
-    /// @param pol Array of polarization vectors for each initial particle (all |pol| ≤ 1)
-    /// @note This overload is only enabled for polarized scattering
-    auto InitialStatePolarization(const std::array<Vector3D, M>& pol) -> void
+    auto ISPolarization(int i, Vector3D pol) -> void
         requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
 
     /// @brief Add an identical particle index set

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.h++
@@ -36,6 +36,8 @@
 
 #include "muc/array"
 #include "muc/chrono"
+#include "muc/hash_map"
+#include "muc/hash_set"
 #include "muc/math"
 #include "muc/numeric"
 #include "muc/utility"
@@ -63,7 +65,10 @@ namespace Mustard::inline Physics::inline Generator {
 /// @brief Generator based on a matrix element.
 ///
 /// Generates events distributed according to 1/S × |M|² × acceptance, and
-/// weight = 1 / acceptance.
+/// weight = 1 / acceptance. Here S is the final state symmetry factor,
+/// |M|² is the matrix element (squared amplitude), acceptance is a user-defined
+/// function (normally 0 <= acceptance <= 1) to apply importance sampling,
+/// and J is the Jacobian of the phase space transformation (e.g. from GENBOD)
 ///
 /// @tparam M Number of initial-state particles
 /// @tparam N Number of final-state particles
@@ -77,7 +82,7 @@ public:
     using typename EventGenerator<M, N>::FinalStateMomenta;
     /// @brief Generated event type
     using typename EventGenerator<M, N>::Event;
-    /// @brief User-defined acceptance function type
+    /// @brief User-defined acceptance function type (normally 0 <= acceptance <= 1)
     using AcceptanceFunction = std::function<auto(const FinalStateMomenta&)->double>;
 
 public:
@@ -178,32 +183,38 @@ protected:
     /// @param i Set index (0 ≤ i < number of sets)
     /// @return Identical particle index set
     auto IdenticalSet(int i) const -> const auto& { return fIdenticalSet[i]; }
-    /// @brief Set IR cuts for single final-state particle
+
+    /// @brief Set low-energy cutoff for single final-state particle to avoid infrared divergence (if applicable)
     /// @param i Particle index (0 ≤ i < N)
-    /// @param cut IR cut value (kinetic energy)
-    auto IRCut(int i, double cut) -> void;
-    /// @brief Check final-state momenta pass the IR cut
+    /// @param cutoff Soft cutoff value (on kinetic energy in the c.m. frame)
+    auto SoftCutoff(int i, double cutoff) -> void;
+    /// @brief Set collinear cutoff for two particles to avoid infrared divergence (if applicable)
+    /// @param pID Pair of particle indices (0 ≤ index < N)
+    /// @param cutoff Collinear cutoff value (on angle between the two particles in the c.m. frame)
+    auto CollinearCutoff(std::pair<int, int> pID, double cutoff) -> void;
+    /// @brief Check final-state momenta pass the soft cutoff and collinear cutoff (i.e. are IR-safe)
     /// @param pF Final states' 4-momenta
-    /// @return true if momenta is IR-safe
-    auto IRSafe(const FinalStateMomenta& pF) const -> bool;
+    /// @return true if momenta are IR-safe
+    auto InfraredSafe(FinalStateMomenta pF) const -> bool;
 
-    /// @brief Set user-defined acceptance function (0 <= acceptance <= 1 recommended)
+    /// @brief Set user-defined acceptance function (normally 0 <= acceptance <= 1)
     /// (PDF = 1/S × |M|² × acceptance, weight = 1 / acceptance)
-    /// @param B User-defined acceptance
-    auto Acceptance(AcceptanceFunction Acceptance) -> void;
-
+    /// @param acceptance User-defined acceptance
+    auto Acceptance(AcceptanceFunction acceptance) -> void;
     /// @brief Get acceptance with range check
     /// @param pF Final states' 4-momenta
     /// @exception `std::runtime_error` if invalid acceptance value produced
-    /// @return B(p1, ..., pN)
-    auto ValidAcceptance(const FinalStateMomenta& pF) const -> double;
-    /// @brief Get reweighted PDF value with range check
+    /// @return acceptance(p1, ..., pN)
+    auto Acceptance(const FinalStateMomenta& pF) const -> double;
+
+    /// @brief Get weighted PDF value with range check
     /// @param pF Final states' 4-momenta
     /// @param event Final states from phase space
-    /// @param acceptance Acceptance value at the same phase space point (from ValidAcceptance)
+    /// @param acceptance Acceptance value at the same phase space point (from `Acceptance(const FinalStateMomenta& pF)`)
     /// @exception `std::runtime_error` if invalid PDF value produced
-    /// @return 1/S × |M|²(p1, ..., pN) × acceptance(p1, ..., pN) × |J|(p1, ..., pN)
-    auto ValidMSqAcceptanceDetJ(const FinalStateMomenta& pF, double acceptance, double detJ) const -> double;
+    /// @return 1/S × |M|²(p1, ..., pN) × acceptance(p1, ..., pN) × |J|(p1, ..., pN), where S is
+    /// the final state symmetry factor, and J is the Jacobian of the phase space transformation (e.g. from GENBOD)
+    auto MSqAcceptanceDetJ(const FinalStateMomenta& pF, double acceptance, double detJ) const -> double;
 
 private:
     /// @brief Monte Carlo integration implementation
@@ -215,14 +226,20 @@ protected:
     GENBOD<M, N> fGENBOD;                   ///< Phase space generator
 
 private:
-    InitialStateMomenta fISMomenta;              ///< Initial-state 4-momenta
-    Vector3D fBoostFromLabToCM;                  ///< Boost from lab frame to c.m. frame
-    double fFSSymmetryFactor;                    ///< Final-state identical particle symmetry factor
-    std::vector<std::vector<int>> fIdenticalSet; ///< Identical particle sets
-    std::vector<std::pair<int, double>> fIRCut;  ///< IR cuts (kinetic energies)
-    AcceptanceFunction fAcceptance;              ///< User acceptance function
-    mutable std::int8_t fAcceptanceGt1Counter;   ///< Counter of acceptance > 1 warning
-    mutable std::int8_t fNegativeMSqCounter;     ///< Counter of negative |M|² warning
+    InitialStateMomenta fISMomenta;                                   ///< Initial-state 4-momenta
+    Vector3D fBoostFromLabToCM;                                       ///< Boost from lab frame to c.m. frame
+                                                                      //
+    double fFSSymmetryFactor;                                         ///< Final-state identical particle symmetry factor
+    std::vector<std::vector<int>> fIdenticalSet;                      ///< Identical particle sets
+                                                                      //
+    muc::flat_hash_map<int, double> fSoftCutoff;                      ///< Soft cutoffs (on kinetic energies in the c.m. frame)
+    muc::flat_hash_map<std::pair<int, int>, double> fCollinearCutoff; ///< Collinear cutoffs (on cosine of angles between particles in the c.m. frame)
+    muc::flat_hash_set<int> fInfraredUnsafePID;                       ///< Particle indices involved in IR cutoffs
+                                                                      //
+    AcceptanceFunction fAcceptance;                                   ///< User acceptance function (normally 0 <= acceptance <= 1)
+                                                                      //
+    mutable std::int8_t fAcceptanceGt1Counter;                        ///< Counter of acceptance > 1 warning
+    mutable std::int8_t fNegativeMSqCounter;                          ///< Counter of negative |M|² warning
 };
 
 } // namespace Mustard::inline Physics::inline Generator

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
@@ -98,7 +98,7 @@ auto MatrixElementBasedGenerator<M, N, A>::PhaseSpaceIntegral(Executor<unsigned 
                 "The integral of |M|^2 * (Acceptance) over phase space:\n"
                 "  {} +/- {}  (rel. unc.: {:.3}%, N_eff: {:.2f})\n",
                 time, sumF, sumF2, nSample, integral.value, integral.uncertainty,
-                integral.uncertainty / integral.value * 100, nEff);
+                integral.uncertainty / std::abs(integral.value) * 100, nEff);
     return {integral, nEff, integrationState};
 }
 
@@ -167,6 +167,10 @@ auto MatrixElementBasedGenerator<M, N, A>::SoftCutoff(int i, double cutoff) -> v
         PrintError(fmt::format("Invalid particle index (valid range is [0, {}), got {})", N, i));
         return;
     }
+    if (not std::isfinite(cutoff)) [[unlikely]] {
+        PrintError(fmt::format("Non-finite soft cutoff for particle {} not allowed (got {}), not setting it", i, cutoff));
+        return;
+    }
     if (cutoff <= 0) [[unlikely]] {
         PrintWarning(fmt::format("Non-positive soft cutoff for particle {} (got {})", i, cutoff));
     }
@@ -186,6 +190,10 @@ auto MatrixElementBasedGenerator<M, N, A>::CollinearCutoff(std::pair<int, int> p
     }
     if (i == j) [[unlikely]] {
         PrintError(fmt::format("Collinear cutoff cannot be set for the same particle (got (i, j) = {})", pID));
+        return;
+    }
+    if (not std::isfinite(cutoff)) [[unlikely]] {
+        PrintError(fmt::format("Non-finite collinear cutoff for particle pair {} not allowed (got {}), not setting it", pID, cutoff));
         return;
     }
     if (cutoff <= 0 or CLHEP::pi <= cutoff) [[unlikely]] {
@@ -239,7 +247,7 @@ auto MatrixElementBasedGenerator<M, N, A>::Acceptance(const FinalStateMomenta& p
         return where;
     }};
     if (not std::isfinite(acceptance)) {
-        Throw<std::runtime_error>(fmt::format("Infinite acceptance found (got {} at {})", acceptance, Format(pF)));
+        Throw<std::runtime_error>(fmt::format("Non-finite acceptance found (got {} at {})", acceptance, Format(pF)));
     }
     if (acceptance < 0) {
         Throw<std::runtime_error>(fmt::format("Negative acceptance found (got {} at {})", acceptance, Format(pF)));
@@ -287,7 +295,7 @@ auto MatrixElementBasedGenerator<M, N, A>::MSqAcceptanceDetJ(const FinalStateMom
         }
     }
     if (not std::isfinite(result)) {
-        Throw<std::runtime_error>(fmt::format("Infinite 1/S * |M|^2 * acceptance * |J| found (got {} at {})", result, Format(pF, acceptance, detJ)));
+        Throw<std::runtime_error>(fmt::format("Non-finite 1/S * |M|^2 * acceptance * |J| found (got {} at {})", result, Format(pF, acceptance, detJ)));
     }
     return result;
 }
@@ -344,7 +352,7 @@ auto MatrixElementBasedGenerator<M, N, A>::Integrate(std::regular_invocable<cons
         }
         MasterPrintLn("Integrate with {} samples. Precision goal: {:.3}.", batchSize, precisionGoal);
         const auto [integral, nEff]{Integrate(batchSize)};
-        const auto precision{integral.uncertainty / integral.value};
+        const auto precision{integral.uncertainty / std::abs(integral.value)};
         if (precision <= precisionGoal) {
             MasterPrint("Current precision: {:.3}, N_eff: {:.2f}, precision goal {:.3} reached.\n"
                         "\n"

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
@@ -93,7 +93,7 @@ auto MatrixElementBasedGenerator<M, N, A>::PhaseSpaceIntegral(Executor<unsigned 
     // Report result
     const auto& [summation, nSample]{integrationState};
     MasterPrint("Integration completed in {:.3f}s.\n"
-                "Integration state (integration can be contined from here):\n"
+                "Integration state (integration can be continued from here):\n"
                 "  {} {} {}\n"
                 "The integral of |M|^2 * (Acceptance) over phase space:\n"
                 "  {} +/- {}  (rel. unc.: {:.3}%, N_eff: {:.2f})\n",

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
@@ -191,7 +191,7 @@ auto MatrixElementBasedGenerator<M, N, A>::CollinearCutoff(std::pair<int, int> p
     if (cutoff <= 0) [[unlikely]] {
         PrintWarning(fmt::format("Non-positive collinear cutoff for particle pair {} (got {})", pID, cutoff));
     }
-    fCollinearCutoff[pID] = std::cos(cutoff);
+    fCollinearCutoff[pID] = std::cos(cutoff); // store cosθ to speed up the check (cosθ ≥ cutoff means θ ≤ cutoff, i.e. collinear)
     fInfraredUnsafePID.insert(i);
     fInfraredUnsafePID.insert(j);
 }

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
@@ -23,7 +23,7 @@ MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialS
     EventGenerator<M, N>{},
     fMatrixElement{},
     fGENBOD{pdgID, mass},
-    fISMomenta{},
+    fMomenta{},
     fBoostFromLabToCM{},
     fFSSymmetryFactor{1},
     fIdenticalSet{},
@@ -33,7 +33,7 @@ MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialS
     fAcceptance{},
     fAcceptanceGt1Counter{},
     fNegativeMSqCounter{} {
-    ISMomenta(pI);
+    Momenta(pI);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
@@ -41,7 +41,7 @@ MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialS
                                                                   const std::array<int, N>& pdgID, const std::array<double, N>& mass) // clang-format off
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> : // clang-format on
     MatrixElementBasedGenerator{pI, pdgID, mass} {
-    ISPolarization(polarization);
+    Polarization(polarization);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
@@ -103,33 +103,33 @@ auto MatrixElementBasedGenerator<M, N, A>::PhaseSpaceIntegral(Executor<unsigned 
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::ISMomenta(const InitialStateMomenta& pI) -> void {
-    fISMomenta = pI;
+auto MatrixElementBasedGenerator<M, N, A>::Momenta(const InitialStateMomenta& pI) -> void {
+    fMomenta = pI;
     fBoostFromLabToCM = -this->CalculateBoost(pI);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::ISPolarization() const -> const typename A::InitialStatePolarization&
+auto MatrixElementBasedGenerator<M, N, A>::Polarization() const -> const typename A::InitialStatePolarization&
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
-    return fMatrixElement.ISPolarization();
+    return fMatrixElement.Polarization();
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::ISPolarization(int i) const -> Vector3D
+auto MatrixElementBasedGenerator<M, N, A>::Polarization(int i) const -> Vector3D
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
-    return fMatrixElement.ISPolarization(i);
+    return fMatrixElement.Polarization(i);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::ISPolarization(const typename A::InitialStatePolarization& pol) -> void
+auto MatrixElementBasedGenerator<M, N, A>::Polarization(const typename A::InitialStatePolarization& pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
-    fMatrixElement.ISPolarization(pol);
+    fMatrixElement.Polarization(pol);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::ISPolarization(int i, Vector3D pol) -> void
+auto MatrixElementBasedGenerator<M, N, A>::Polarization(int i, Vector3D pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
-    fMatrixElement.ISPolarization(i, pol);
+    fMatrixElement.Polarization(i, pol);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
@@ -263,7 +263,7 @@ auto MatrixElementBasedGenerator<M, N, A>::MSqAcceptanceDetJ(const FinalStateMom
     if (acceptance <= std::numeric_limits<double>::epsilon()) {
         return 0;
     }
-    const auto mSq{fMatrixElement(fISMomenta, pF)};
+    const auto mSq{fMatrixElement(fMomenta, pF)};
     const auto result{fFSSymmetryFactor * mSq * acceptance * detJ}; // 1/S × |M|² × acceptance × |J|
     constexpr auto Format{[](const FinalStateMomenta& pF, double acceptance, double detJ) {
         auto where{fmt::format("({})", detJ)};

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
@@ -37,19 +37,11 @@ MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialS
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialStateMomenta& pI, Vector3D polarization,
+MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                                                                   const std::array<int, N>& pdgID, const std::array<double, N>& mass) // clang-format off
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> : // clang-format on
     MatrixElementBasedGenerator{pI, pdgID, mass} {
-    fMatrixElement.InitialStatePolarization(polarization);
-}
-
-template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
-                                                                  const std::array<int, N>& pdgID, const std::array<double, N>& mass) // clang-format off
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) : // clang-format on
-    MatrixElementBasedGenerator{pI, pdgID, mass} {
-    fMatrixElement.InitialStatePolarization(polarization);
+    ISPolarization(polarization);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
@@ -105,39 +97,27 @@ auto MatrixElementBasedGenerator<M, N, A>::ISMomenta(const InitialStateMomenta& 
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization() const -> Vector3D
+auto MatrixElementBasedGenerator<M, N, A>::ISPolarization() const -> const typename A::InitialStatePolarization&
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
-    return fMatrixElement.InitialStatePolarization();
+    return fMatrixElement.ISPolarization();
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization(int i) const -> Vector3D
+auto MatrixElementBasedGenerator<M, N, A>::ISPolarization(int i) const -> Vector3D
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
-    return fMatrixElement.InitialStatePolarization(i);
+    return fMatrixElement.ISPolarization(i);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization() const -> const std::array<Vector3D, M>&
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
-    return fMatrixElement.InitialStatePolarization();
-}
-
-template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization(Vector3D pol) -> void
+auto MatrixElementBasedGenerator<M, N, A>::ISPolarization(const typename A::InitialStatePolarization& pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
-    fMatrixElement.InitialStatePolarization(pol);
+    fMatrixElement.ISPolarization(pol);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization(int i, Vector3D pol) -> void
+auto MatrixElementBasedGenerator<M, N, A>::ISPolarization(int i, Vector3D pol) -> void
     requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
-    fMatrixElement.InitialStatePolarization(i, pol);
-}
-
-template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::InitialStatePolarization(const std::array<Vector3D, M>& pol) -> void
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) {
-    fMatrixElement.InitialStatePolarization(pol);
+    fMatrixElement.ISPolarization(i, pol);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
@@ -48,9 +48,21 @@ template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MatrixElementBasedGenerator<M, N, A>::PhaseSpaceIntegral(Executor<unsigned long long>& executor, double precisionGoal,
                                                               MCIntegrationState integrationState,
                                                               CLHEP::HepRandomEngine& rng) -> std::tuple<Estimate, double, MCIntegrationState> {
-    MasterPrint("Integrating |M|^2 * (Acceptance) over phase space in {}.\n"
-                "\n",
-                muc::try_demangle(typeid(*this).name()));
+    MasterPrintLn("Integrating |M|^2 * (Acceptance) over phase space in {}.\n", muc::try_demangle(typeid(*this).name()));
+    if (fInfraredUnsafePID.empty()) {
+        MasterPrintLn("No infrared cutoff is set.\n");
+    } else {
+        MasterPrintLn("Infrared cutoff(s) in the c.m. frame:");
+        for (auto&& [i, cutoff] : std::as_const(fSoftCutoff)) {
+            MasterPrintLn("  Soft cutoff for particle {}: k.e. > {}", i, cutoff);
+        }
+        for (auto&& [i, cutoff] : std::as_const(fCollinearCutoff)) {
+            const auto radian{std::acos(cutoff)};
+            const auto degree{radian / CLHEP::degree};
+            MasterPrintLn("  Collinear cutoff for particle {}: angle(p{}, p{}) > {:.6} rad ({:.6} deg)", i, i.first, i.second, radian, degree);
+        }
+        MasterPrint("\n");
+    }
 
     // Reseed random engine for statistical safety
     Parallel::ReseedRandomEngine(&rng);
@@ -124,7 +136,7 @@ template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MatrixElementBasedGenerator<M, N, A>::AddIdenticalSet(std::vector<int> set) -> void {
     for (auto&& i : std::as_const(set)) {
         if (i < 0 or i >= N) [[unlikely]] {
-            PrintError(fmt::format("Invalid particle index in identical set (valid range is [0,{}), got {}), ignoring the set", N, i));
+            PrintError(fmt::format("Invalid particle index in identical set (valid range is [0, {}), got {}), ignoring the set", N, i));
             return;
         }
     }
@@ -152,7 +164,7 @@ auto MatrixElementBasedGenerator<M, N, A>::AddIdenticalSet(std::vector<int> set)
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MatrixElementBasedGenerator<M, N, A>::SoftCutoff(int i, double cutoff) -> void {
     if (i < 0 or i >= N) [[unlikely]] {
-        PrintError(fmt::format("Invalid particle index (valid range is [0,{}), got {})", N, i));
+        PrintError(fmt::format("Invalid particle index (valid range is [0, {}), got {})", N, i));
         return;
     }
     if (cutoff <= 0) [[unlikely]] {
@@ -169,11 +181,11 @@ auto MatrixElementBasedGenerator<M, N, A>::CollinearCutoff(std::pair<int, int> p
         std::swap(i, j);
     }
     if (i < 0 or i >= N or j < 0 or j >= N) [[unlikely]] {
-        PrintError(fmt::format("Invalid particle index (valid range is [0,{}), got (i,j) = {})", N, pID));
+        PrintError(fmt::format("Invalid particle index (valid range is [0, {}), got (i, j) = {})", N, pID));
         return;
     }
     if (i == j) [[unlikely]] {
-        PrintError(fmt::format("Collinear cutoff cannot be set for the same particle (got (i,j) = {})", pID));
+        PrintError(fmt::format("Collinear cutoff cannot be set for the same particle (got (i, j) = {})", pID));
         return;
     }
     if (cutoff <= 0) [[unlikely]] {

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
@@ -27,8 +27,10 @@ MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialS
     fBoostFromLabToCM{},
     fFSSymmetryFactor{1},
     fIdenticalSet{},
-    fIRCut{},
-    fAcceptance{[](auto&&) { return 1; }},
+    fSoftCutoff{},
+    fCollinearCutoff{},
+    fInfraredUnsafePID{},
+    fAcceptance{},
     fAcceptanceGt1Counter{},
     fNegativeMSqCounter{} {
     ISMomenta(pI);
@@ -54,7 +56,7 @@ template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MatrixElementBasedGenerator<M, N, A>::PhaseSpaceIntegral(Executor<unsigned long long>& executor, double precisionGoal,
                                                               MCIntegrationState integrationState,
                                                               CLHEP::HepRandomEngine& rng) -> std::tuple<Estimate, double, MCIntegrationState> {
-    MasterPrint("Integrate |M|^2 x (Acceptance) on phase space in {}.\n"
+    MasterPrint("Integrating |M|^2 * (Acceptance) over phase space in {}.\n"
                 "\n",
                 muc::try_demangle(typeid(*this).name()));
 
@@ -74,8 +76,8 @@ auto MatrixElementBasedGenerator<M, N, A>::PhaseSpaceIntegral(Executor<unsigned 
     // Start integration
     const auto Integrand{[this](const Event& event) {
         const auto& [detJ, _, pF]{event};
-        const auto acceptance{ValidAcceptance(pF)};
-        return ValidMSqAcceptanceDetJ(pF, acceptance, detJ);
+        const auto acceptance{Acceptance(pF)};
+        return MSqAcceptanceDetJ(pF, acceptance, detJ);
     }};
     muc::chrono::stopwatch stopwatch;
     const auto [integral, nEff]{Integrate(Integrand, precisionGoal, integrationState, executor, rng)};
@@ -89,7 +91,7 @@ auto MatrixElementBasedGenerator<M, N, A>::PhaseSpaceIntegral(Executor<unsigned 
     MasterPrint("Integration completed in {:.3f}s.\n"
                 "Integration state (integration can be contined from here):\n"
                 "  {} {} {}\n"
-                "|M|^2 x (Acceptance) phase-space integral:\n"
+                "The integral of |M|^2 * (Acceptance) over phase space:\n"
                 "  {} +/- {}  (rel. unc.: {:.3}%, N_eff: {:.2f})\n",
                 time, summation[0], summation[1], nSample, integral.value, integral.uncertainty,
                 integral.uncertainty / integral.value * 100, nEff);
@@ -142,7 +144,7 @@ template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MatrixElementBasedGenerator<M, N, A>::AddIdenticalSet(std::vector<int> set) -> void {
     for (auto&& i : std::as_const(set)) {
         if (i < 0 or i >= N) [[unlikely]] {
-            PrintError(fmt::format("Invalid particle index in identical set (valid range is [0, {}), got {}), ignoring the set", N, i));
+            PrintError(fmt::format("Invalid particle index in identical set (valid range is [0,{}), got {}), ignoring the set", N, i));
             return;
         }
     }
@@ -168,19 +170,55 @@ auto MatrixElementBasedGenerator<M, N, A>::AddIdenticalSet(std::vector<int> set)
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::IRCut(int i, double cut) -> void {
-    if (cut <= 0) [[unlikely]] {
-        PrintWarning(fmt::format("Non-positive IR cut for particle {} (got {})", i, cut));
+auto MatrixElementBasedGenerator<M, N, A>::SoftCutoff(int i, double cutoff) -> void {
+    if (i < 0 or i >= N) [[unlikely]] {
+        PrintError(fmt::format("Invalid particle index (valid range is [0,{}), got {})", N, i));
+        return;
     }
-    fIRCut.push_back({i, cut});
+    if (cutoff <= 0) [[unlikely]] {
+        PrintWarning(fmt::format("Non-positive soft cutoff for particle {} (got {})", i, cutoff));
+    }
+    fSoftCutoff[i] = cutoff;
+    fInfraredUnsafePID.insert(i);
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::IRSafe(const FinalStateMomenta& pF) const -> bool {
-    for (auto&& [i, cut] : fIRCut) {
-        auto p{pF[i]};
-        p.boost(fBoostFromLabToCM);
-        if (p.e() - p.m() <= cut) {
+auto MatrixElementBasedGenerator<M, N, A>::CollinearCutoff(std::pair<int, int> pID, double cutoff) -> void {
+    auto& [i, j]{pID};
+    if (i > j) {
+        std::swap(i, j);
+    }
+    if (i < 0 or i >= N or j < 0 or j >= N) [[unlikely]] {
+        PrintError(fmt::format("Invalid particle index (valid range is [0,{}), got (i,j) = {})", N, pID));
+        return;
+    }
+    if (i == j) [[unlikely]] {
+        PrintError(fmt::format("Collinear cutoff cannot be set for the same particle (got (i,j) = {})", pID));
+        return;
+    }
+    if (cutoff <= 0) [[unlikely]] {
+        PrintWarning(fmt::format("Non-positive collinear cutoff for particle pair {} (got {})", pID, cutoff));
+    }
+    fCollinearCutoff[pID] = std::cos(cutoff);
+    fInfraredUnsafePID.insert(i);
+    fInfraredUnsafePID.insert(j);
+}
+
+template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
+auto MatrixElementBasedGenerator<M, N, A>::InfraredSafe(FinalStateMomenta pF) const -> bool {
+    for (auto&& i : std::as_const(fInfraredUnsafePID)) {
+        pF[i].boost(fBoostFromLabToCM);
+    }
+    for (auto&& [i, cutoff] : std::as_const(fSoftCutoff)) {
+        const auto& p{pF[i]};
+        if (p.e() - p.m() <= cutoff) {
+            return false;
+        }
+    }
+    for (auto&& [i, cutoff] : std::as_const(fCollinearCutoff)) {
+        const auto p1{pF[i.first].vect()};
+        const auto p2{pF[i.second].vect()};
+        if (p1.cosTheta(p2) >= cutoff) { // cosθ ≥ cutoff means θ ≤ cutoff, i.e. collinear
             return false;
         }
     }
@@ -188,13 +226,16 @@ auto MatrixElementBasedGenerator<M, N, A>::IRSafe(const FinalStateMomenta& pF) c
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::Acceptance(AcceptanceFunction Acceptance) -> void {
-    fAcceptance = std::move(Acceptance);
+auto MatrixElementBasedGenerator<M, N, A>::Acceptance(AcceptanceFunction acceptance) -> void {
+    fAcceptance = std::move(acceptance);
     fAcceptanceGt1Counter = 0;
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::ValidAcceptance(const FinalStateMomenta& pF) const -> double {
+auto MatrixElementBasedGenerator<M, N, A>::Acceptance(const FinalStateMomenta& pF) const -> double {
+    if (not fAcceptance) {
+        return 1;
+    }
     const auto acceptance{fAcceptance(pF)};
     constexpr auto Format{[](const FinalStateMomenta& pF) {
         std::string where;
@@ -224,14 +265,14 @@ auto MatrixElementBasedGenerator<M, N, A>::ValidAcceptance(const FinalStateMomen
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::ValidMSqAcceptanceDetJ(const FinalStateMomenta& pF, double acceptance, double detJ) const -> double {
+auto MatrixElementBasedGenerator<M, N, A>::MSqAcceptanceDetJ(const FinalStateMomenta& pF, double acceptance, double detJ) const -> double {
     Expects(acceptance >= 0);
     Expects(detJ > 0);
     if (acceptance <= std::numeric_limits<double>::epsilon()) {
         return 0;
     }
     const auto mSq{fMatrixElement(fISMomenta, pF)};
-    const auto result{fFSSymmetryFactor * mSq * acceptance * detJ}; // 1/S * |M|² × acceptance × |J|
+    const auto result{fFSSymmetryFactor * mSq * acceptance * detJ}; // 1/S × |M|² × acceptance × |J|
     constexpr auto Format{[](const FinalStateMomenta& pF, double acceptance, double detJ) {
         auto where{fmt::format("({})", detJ)};
         for (auto&& p : pF) {
@@ -252,7 +293,7 @@ auto MatrixElementBasedGenerator<M, N, A>::ValidMSqAcceptanceDetJ(const FinalSta
         }
     }
     if (not std::isfinite(result)) {
-        Throw<std::runtime_error>(fmt::format("Infinite |M|^2 x (Acceptance) x |J| found (got {} at {})", result, Format(pF, acceptance, detJ)));
+        Throw<std::runtime_error>(fmt::format("Infinite 1/S * |M|^2 * acceptance * |J| found (got {} at {})", result, Format(pF, acceptance, detJ)));
     }
     return result;
 }
@@ -277,7 +318,7 @@ auto MatrixElementBasedGenerator<M, N, A>::Integrate(std::regular_invocable<cons
         }};
         executor(nSample, [&](auto) {
             const auto event{PhaseSpace(rng)};
-            if (not IRSafe(event.p)) {
+            if (not InfraredSafe(event.p)) {
                 return;
             }
             const auto value{Integrand(event)};

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
@@ -91,13 +91,13 @@ auto MatrixElementBasedGenerator<M, N, A>::PhaseSpaceIntegral(Executor<unsigned 
     }
 
     // Report result
-    const auto& [summation, nSample]{integrationState};
+    const auto& [sumF, sumF2, nSample]{integrationState};
     MasterPrint("Integration completed in {:.3f}s.\n"
                 "Integration state (integration can be continued from here):\n"
                 "  {} {} {}\n"
                 "The integral of |M|^2 * (Acceptance) over phase space:\n"
                 "  {} +/- {}  (rel. unc.: {:.3}%, N_eff: {:.2f})\n",
-                time, summation[0], summation[1], nSample, integral.value, integral.uncertainty,
+                time, sumF, sumF2, nSample, integral.value, integral.uncertainty,
                 integral.uncertainty / integral.value * 100, nEff);
     return {integral, nEff, integrationState};
 }
@@ -188,8 +188,8 @@ auto MatrixElementBasedGenerator<M, N, A>::CollinearCutoff(std::pair<int, int> p
         PrintError(fmt::format("Collinear cutoff cannot be set for the same particle (got (i, j) = {})", pID));
         return;
     }
-    if (cutoff <= 0) [[unlikely]] {
-        PrintWarning(fmt::format("Non-positive collinear cutoff for particle pair {} (got {})", pID, cutoff));
+    if (cutoff <= 0 or CLHEP::pi <= cutoff) [[unlikely]] {
+        PrintWarning(fmt::format("Suspicious collinear cutoff for particle pair {} (expect 0 < cutoff < pi, got {})", pID, cutoff));
     }
     fCollinearCutoff[pID] = std::cos(cutoff); // store cosθ to speed up the check (cosθ ≥ cutoff means θ ≤ cutoff, i.e. collinear)
     fInfraredUnsafePID.insert(i);
@@ -321,26 +321,26 @@ auto MatrixElementBasedGenerator<M, N, A>::Integrate(std::regular_invocable<cons
         if (mplr::available()) {
             mplr::comm_world().allreduce([](auto a, auto b) { return a + b; }, sum);
         }
-        state.sum += sum;
+        state.sumF += sum[0];
+        state.sumF2 += sum[1];
         state.n += nSample;
         Estimate integral;
-        integral.value = state.sum[0] / state.n;
-        integral.uncertainty = std::sqrt((state.sum[1] / state.n - muc::pow(integral.value, 2)) / state.n);
-        const auto nEff{muc::pow(state.sum[0], 2) / state.sum[1]};
+        integral.value = state.sumF / state.n;
+        integral.uncertainty = std::sqrt((state.sumF2 / state.n - muc::pow(integral.value, 2)) / state.n);
+        const auto nEff{muc::pow(state.sumF, 2) / state.sumF2};
         return std::pair{integral, nEff};
     }};
     // Integration loop
     MasterPrintLn("Integration starts. Precision goal: {:.3}.", precisionGoal);
     const auto initialBatchSize{muc::to_unsigned(muc::llround(muc::pow(precisionGoal, -2)))};
     auto batchSize{std::max(1000000ull * executor.NProcess(), initialBatchSize)};
-    double nSamplePerMin{}; // just a very approximate value
     for (int checkpoint{};; ++checkpoint) {
         if (state.n == 0) {
             MasterPrintLn("[Checkpoint {}] Restarting integration.", checkpoint);
         } else {
             MasterPrintLn("[Checkpoint {}] Continuing integration from state\n"
                           "  {} {} {}",
-                          checkpoint, state.sum[0], state.sum[1], state.n);
+                          checkpoint, state.sumF, state.sumF2, state.n);
         }
         MasterPrintLn("Integrate with {} samples. Precision goal: {:.3}.", batchSize, precisionGoal);
         const auto [integral, nEff]{Integrate(batchSize)};
@@ -355,18 +355,18 @@ auto MatrixElementBasedGenerator<M, N, A>::Integrate(std::regular_invocable<cons
         MasterPrint("Current precision: {:.3}, N_eff: {:.2f}, precision goal {:.3} not reached.\n"
                     "\n",
                     precision, nEff, precisionGoal);
-        // Estimate throughput
-        nSamplePerMin = batchSize / muc::chrono::minutes<double>{executor.ExecutionInfo().wallTime}.count();
+        // Estimate throughput, just a very approximate value
+        const auto nSamplePerMin{batchSize / muc::chrono::minutes<double>{executor.ExecutionInfo().wallTime}.count()};
         // Increase total sample size adaptively
-        constexpr auto zFactor{1}; // decrease z sigma to increase stability
-        const auto counterFactor{1 - zFactor / std::sqrt(nEff)};
-        const auto factor{std::max(0., counterFactor * muc::pow(precision / precisionGoal, 2) - 1)};
-        if (std::isfinite(factor)) {
+        if (std::isfinite(precision)) { // finite precision implies finite nEff
+            constexpr auto zFactor{1};  // decrease z sigma to increase stability
+            const auto counterFactor{1 - zFactor / std::sqrt(nEff)};
+            const auto factor{std::max(0., counterFactor * muc::pow(precision / precisionGoal, 2) - 1)};
             batchSize = factor * state.n;
-        } else {
+        } else { // increase the batch size by 10 if we have not even stepped into the real phase space
             batchSize *= 10;
         }
-        // Batch size should not be too samll,
+        // Batch size should not be too small,
         const auto batchSizeLowerBound{std::max<long long>(executor.NProcess(), std::llround(nSamplePerMin))};
         // and not too large
         const auto batchSizeUpperBound{std::llround(15 * nSamplePerMin)};

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
@@ -39,7 +39,7 @@ MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialS
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 MatrixElementBasedGenerator<M, N, A>::MatrixElementBasedGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                                                                   const std::array<int, N>& pdgID, const std::array<double, N>& mass) // clang-format off
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> : // clang-format on
+    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> : // clang-format on
     MatrixElementBasedGenerator{pI, pdgID, mass} {
     Polarization(polarization);
 }
@@ -110,7 +110,7 @@ auto MatrixElementBasedGenerator<M, N, A>::Momenta(const InitialStateMomenta& pI
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MatrixElementBasedGenerator<M, N, A>::Polarization() const -> const typename A::InitialStatePolarization&
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
+    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> {
     return fMatrixElement.Polarization();
 }
 
@@ -122,7 +122,7 @@ auto MatrixElementBasedGenerator<M, N, A>::Polarization(int i) const -> Vector3D
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MatrixElementBasedGenerator<M, N, A>::Polarization(const typename A::InitialStatePolarization& pol) -> void
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> {
+    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> {
     fMatrixElement.Polarization(pol);
 }
 

--- a/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
+++ b/src/Mustard/Physics/Generator/MatrixElementBasedGenerator.inl
@@ -197,19 +197,21 @@ auto MatrixElementBasedGenerator<M, N, A>::CollinearCutoff(std::pair<int, int> p
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-auto MatrixElementBasedGenerator<M, N, A>::InfraredSafe(FinalStateMomenta pF) const -> bool {
+auto MatrixElementBasedGenerator<M, N, A>::InfraredSafe(const FinalStateMomenta& pF) const -> bool {
+    FinalStateMomenta infraredUnsafePF;
     for (auto&& i : std::as_const(fInfraredUnsafePID)) {
-        pF[i].boost(fBoostFromLabToCM);
+        infraredUnsafePF[i] = pF[i];
+        infraredUnsafePF[i].boost(fBoostFromLabToCM);
     }
     for (auto&& [i, cutoff] : std::as_const(fSoftCutoff)) {
-        const auto& p{pF[i]};
+        const auto& p{infraredUnsafePF[i]};
         if (p.e() - p.m() <= cutoff) {
             return false;
         }
     }
     for (auto&& [i, cutoff] : std::as_const(fCollinearCutoff)) {
-        const auto p1{pF[i.first].vect()};
-        const auto p2{pF[i.second].vect()};
+        const auto p1{infraredUnsafePF[i.first].vect()};
+        const auto p2{infraredUnsafePF[i.second].vect()};
         if (p1.cosTheta(p2) >= cutoff) { // cosθ ≥ cutoff means θ ≤ cutoff, i.e. collinear
             return false;
         }

--- a/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.h++
+++ b/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.h++
@@ -125,8 +125,8 @@ private:
     virtual auto NextEvent(CLHEP::HepRandomEngine& rng) -> bool override;
 
 private:
-    Random::Gaussian<double> fGaussian; ///< Gaussian distribution
-    double fStepSize;                   ///< Step scale along one direction in random state space
+    Random::GaussianFast<double> fGaussian; ///< Gaussian distribution
+    double fStepSize;                       ///< Step scale along one direction in random state space
 
     static constexpr auto fgNTrial{5};                                            ///< Number of trial points
     static inline const auto fgScalingFactor{3.12 / std::sqrt(MarkovChain::dim)}; ///< Step size scaling factor. Ref: of M. B´edard et al. SPA 122 (2012) 758–786, https://doi.org/10.1016/j.spa.2011.11.004

--- a/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.h++
+++ b/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.h++
@@ -81,32 +81,18 @@ public:
                                    std::optional<double> stepSize = {});
     /// @brief Construct event generator
     /// @param pI initial-state 4-momenta
-    /// @param polarization Initial-state polarization vector
+    /// @param polarization Initial-state polarization vector(s)
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
     /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     /// @note This overload is only enabled for polarized decay
-    MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, Vector3D polarization,
+    MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                                    const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                    std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {},
                                    std::optional<double> stepSize = {})
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>>;
-    /// @brief Construct event generator
-    /// @param pI initial-state 4-momenta
-    /// @param polarization Initial-state polarization vectors
-    /// @param pdgID Array of particle PDG IDs (index order preserved)
-    /// @param mass Array of particle masses (index order preserved)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
-    /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
-    /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
-    /// @note This overload is only enabled for polarized scattering
-    MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
-                                   const std::array<int, N>& pdgID, const std::array<double, N>& mass,
-                                   std::optional<double> thinningRatio = {}, std::optional<unsigned> acfSampleSize = {},
-                                   std::optional<double> stepSize = {})
-        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1);
+        requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>>;
 
     // Keep the class abstract
     virtual ~MultipleTryMetropolisGenerator() override = 0;

--- a/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.h++
+++ b/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.h++
@@ -73,7 +73,7 @@ public:
     /// @param pI initial-state 4-momenta
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
+    /// @param thinningRatio Thinning factor (non-negative, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, const std::array<int, N>& pdgID, const std::array<double, N>& mass,
@@ -84,7 +84,7 @@ public:
     /// @param polarization Initial-state polarization vector(s)
     /// @param pdgID Array of particle PDG IDs (index order preserved)
     /// @param mass Array of particle masses (index order preserved)
-    /// @param thinningRatio Thinning factor (between 0--1, optional, use default value if not set)
+    /// @param thinningRatio Thinning factor (non-negative, optional, use default value if not set)
     /// @param acfSampleSize Sample size for estimation autocorrelation function (ACF) (optional, use default value if not set)
     /// @param stepSize Step size (proposal sigma) for proposal increment distribution (optional, use default value if not set)
     /// @note This overload is only enabled for polarized decay

--- a/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.inl
+++ b/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.inl
@@ -67,7 +67,7 @@ auto MultipleTryMetropolisGenerator<M, N, A>::StepSize(double stepSize) -> void 
         PrintError(fmt::format("Infinite MCMC step size (got {})", stepSize));
     }
     if (stepSize <= std::numeric_limits<double>::epsilon() or 0.5 <= stepSize) [[unlikely]] {
-        PrintWarning(fmt::format("Suspicious MCMC step size (expects {} < step size < 0.5, got {})", stepSize, std::numeric_limits<double>::epsilon()));
+        PrintWarning(fmt::format("Suspicious MCMC step size (expects {} < step size < 0.5, got {})", std::numeric_limits<double>::epsilon(), stepSize));
     }
     // Rescale stepSize
     // E(distance in d-dim space) ~ sqrt(d), if stepSize = stepSize0 / sqrt(d) => E(step size) ~ stepSize0

--- a/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.inl
+++ b/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.inl
@@ -50,7 +50,7 @@ MultipleTryMetropolisGenerator<M, N, A>::~MultipleTryMetropolisGenerator() = def
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MultipleTryMetropolisGenerator<M, N, A>::StepSize(double stepSize) -> void {
     if (not std::isfinite(stepSize)) [[unlikely]] {
-        PrintError(fmt::format("Infinite MCMC step size (got {}) not allowed, not setting it", stepSize));
+        PrintError(fmt::format("Non-finite MCMC step size (got {}) not allowed, not setting it", stepSize));
         return;
     }
     if (stepSize <= std::numeric_limits<double>::epsilon() or 0.5 <= stepSize) [[unlikely]] {

--- a/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.inl
+++ b/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.inl
@@ -66,8 +66,8 @@ auto MultipleTryMetropolisGenerator<M, N, A>::StepSize(double stepSize) -> void 
     if (not std::isfinite(stepSize)) [[unlikely]] {
         PrintError(fmt::format("Infinite MCMC step size (got {})", stepSize));
     }
-    if (stepSize <= muc::default_abs_tol<double> or 0.5 <= stepSize) [[unlikely]] {
-        PrintWarning(fmt::format("Suspicious MCMC step size (got {}, expects {} < step size < 0.5)", stepSize, muc::default_abs_tol<double>));
+    if (stepSize <= std::numeric_limits<double>::epsilon() or 0.5 <= stepSize) [[unlikely]] {
+        PrintWarning(fmt::format("Suspicious MCMC step size (expects {} < step size < 0.5, got {})", stepSize, std::numeric_limits<double>::epsilon()));
     }
     // Rescale stepSize
     // E(distance in d-dim space) ~ sqrt(d), if stepSize = stepSize0 / sqrt(d) => E(step size) ~ stepSize0
@@ -119,12 +119,12 @@ auto MultipleTryMetropolisGenerator<M, N, A>::NextEvent(CLHEP::HepRandomEngine& 
         ProposeState(this->fMC.state, stateY[i]); // Draw y_i from T(x, *)
         double detJ;
         std::tie(eventY[i], detJ) = this->PhaseSpace(stateY[i]); // y_i -> event(y_i) = g(y_i), also get |J|(g(y_i))
-        if (not this->IRSafe(eventY[i].p)) {
+        if (not this->InfraredSafe(eventY[i].p)) {
             piY[i] = 0;
             continue;
         }
-        acceptanceY[i] = this->ValidAcceptance(eventY[i].p);                      // g(y_i) -> B(g(y_i))
-        piY[i] = this->ValidMSqAcceptanceDetJ(eventY[i].p, acceptanceY[i], detJ); // g(y_i) -> pi(y_i) = |M|²(g(y_i)) × B(g(y_i)) × |J|(g(y_i))
+        acceptanceY[i] = this->Acceptance(eventY[i].p);                      // g(y_i) -> B(g(y_i))
+        piY[i] = this->MSqAcceptanceDetJ(eventY[i].p, acceptanceY[i], detJ); // g(y_i) -> pi(y_i) = |M|²(g(y_i)) × B(g(y_i)) × |J|(g(y_i))
     }
     const auto sumPiY{muc::ranges::reduce(piY)}; // pi(y_1) + ... + pi(y_k)
     const auto selected{[&] {                    // Select Y from y_1, ..., y_k by pi(y_1), ..., pi(y_k)
@@ -144,11 +144,11 @@ auto MultipleTryMetropolisGenerator<M, N, A>::NextEvent(CLHEP::HepRandomEngine& 
     for (int i{}; i < fgNTrial - 1; ++i) {
         ProposeState(stateY[selected], stateX);             // Draw x_i from T(Y, *)
         const auto [event, detJ]{this->PhaseSpace(stateX)}; // x_i -> event(x_i) = g(x_i), also get |J|(g(x_i))
-        if (not this->IRSafe(event.p)) {
+        if (not this->InfraredSafe(event.p)) {
             continue;
         }
-        const auto acceptanceX{this->ValidAcceptance(event.p)};             // g(x_i) -> B(g(x_i))
-        sumPiX += this->ValidMSqAcceptanceDetJ(event.p, acceptanceX, detJ); // g(x_i) -> pi(x_i) = |M|²(g(x_i)) × B(g(x_i)) × |J|(g(y_i))
+        const auto acceptanceX{this->Acceptance(event.p)};             // g(x_i) -> B(g(x_i))
+        sumPiX += this->MSqAcceptanceDetJ(event.p, acceptanceX, detJ); // g(x_i) -> pi(x_i) = |M|²(g(x_i)) × B(g(x_i)) × |J|(g(y_i))
     }
 
     // accept/reject Y

--- a/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.inl
+++ b/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.inl
@@ -50,7 +50,8 @@ MultipleTryMetropolisGenerator<M, N, A>::~MultipleTryMetropolisGenerator() = def
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
 auto MultipleTryMetropolisGenerator<M, N, A>::StepSize(double stepSize) -> void {
     if (not std::isfinite(stepSize)) [[unlikely]] {
-        PrintError(fmt::format("Infinite MCMC step size (got {})", stepSize));
+        PrintError(fmt::format("Infinite MCMC step size (got {}) not allowed, not setting it", stepSize));
+        return;
     }
     if (stepSize <= std::numeric_limits<double>::epsilon() or 0.5 <= stepSize) [[unlikely]] {
         PrintWarning(fmt::format("Suspicious MCMC step size (expects {} < step size < 0.5, got {})", std::numeric_limits<double>::epsilon(), stepSize));
@@ -67,7 +68,7 @@ auto MultipleTryMetropolisGenerator<M, N, A>::BurnIn(CLHEP::HepRandomEngine& rng
     // i.e. sqrt(random walk distance) >~ scale * sqrt(dimension)
     constexpr auto travelScale{10};
     double distance{};
-    while (distance > muc::pow(travelScale, 2) * MarkovChain::dim) {
+    while (distance < muc::pow(travelScale, 2) * MarkovChain::dim) {
         if (NextEvent(rng)) {
             distance += fStepSize;
         }

--- a/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.inl
+++ b/src/Mustard/Physics/Generator/MultipleTryMetropolisGenerator.inl
@@ -31,25 +31,11 @@ MultipleTryMetropolisGenerator<M, N, A>::MultipleTryMetropolisGenerator(const In
 }
 
 template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-MultipleTryMetropolisGenerator<M, N, A>::MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, Vector3D polarization,
+MultipleTryMetropolisGenerator<M, N, A>::MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, const typename A::InitialStatePolarization& polarization,
                                                                         const std::array<int, N>& pdgID, const std::array<double, N>& mass,
                                                                         std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize,
                                                                         std::optional<double> stepSize) // clang-format off
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<1, N>> : // clang-format on
-    Base{pI, polarization, pdgID, mass, std::move(thinningRatio), std::move(acfSampleSize)},
-    fGaussian{},
-    fStepSize{std::numeric_limits<double>::quiet_NaN()} {
-    if (stepSize) {
-        StepSize(*stepSize);
-    }
-}
-
-template<int M, int N, std::derived_from<QFT::MatrixElement<M, N>> A>
-MultipleTryMetropolisGenerator<M, N, A>::MultipleTryMetropolisGenerator(const InitialStateMomenta& pI, const std::array<Vector3D, M>& polarization,
-                                                                        const std::array<int, N>& pdgID, const std::array<double, N>& mass,
-                                                                        std::optional<double> thinningRatio, std::optional<unsigned> acfSampleSize,
-                                                                        std::optional<double> stepSize) // clang-format off
-    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> and (M > 1) : // clang-format on
+    requires std::derived_from<A, QFT::PolarizedMatrixElement<M, N>> : // clang-format on
     Base{pI, polarization, pdgID, mass, std::move(thinningRatio), std::move(acfSampleSize)},
     fGaussian{},
     fStepSize{std::numeric_limits<double>::quiet_NaN()} {

--- a/src/Mustard/Physics/Generator/RAMBO.h++
+++ b/src/Mustard/Physics/Generator/RAMBO.h++
@@ -81,7 +81,7 @@ public:
     /// @param pI Initial-state 4-momenta
     /// @return Generated event
     virtual auto operator()(const RandomState& u, InitialStateMomenta pI) -> Event override;
-    // Inherit operator() overloads
+    // Avoid hiding other operator() overloads from base class
     using VersatileEventGenerator<M, N, 4 * N>::operator();
 
 private:

--- a/src/Mustard/Physics/Generator/RAMBO.inl
+++ b/src/Mustard/Physics/Generator/RAMBO.inl
@@ -94,13 +94,10 @@ auto RAMBO<M, N>::operator()(const RandomState& u, InitialStateMomenta pI) -> Ev
 
     // generate N massless momenta in infinite phase space
     for (int i = 0; i < N; i++) {
-        double r1 = u[4 * i];
-        double c = 2. * r1 - 1.;
+        double c = 2. * u[4 * i] - 1.;
         double s = std::sqrt(1. - c * c);
         double f = twopi * u[4 * i + 1];
-        r1 = u[4 * i + 2];
-        double r2 = u[4 * i + 3];
-        q[i][0] = -std::log(r1 * r2);
+        q[i][0] = -std::log(u[4 * i + 2] * u[4 * i + 3]);
         q[i][3] = q[i][0] * c;
         q[i][2] = q[i][0] * s * std::cos(f);
         q[i][1] = q[i][0] * s * std::sin(f);

--- a/src/Mustard/Physics/QFT/MSqM2ENNEE.c++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNEE.c++
@@ -62,7 +62,7 @@ auto MSqM2ENNEE::MSqMcMule0Av(const InitialStateMomenta& pI, const FinalStateMom
     const auto m12{p1.m2()};
     const auto m32{p3.m2()};
 
-    const auto polarized{InitialStatePolarization() != Vector3D{}};
+    const auto polarized{ISPolarization() != Vector3D{}};
     const auto sqrtM12{polarized ? std::sqrt(m12) : 0};
 
     double pm2enneeav{};
@@ -76,7 +76,7 @@ auto MSqM2ENNEE::MSqMcMule0Av(const InitialStateMomenta& pI, const FinalStateMom
         pm2enneeav += 2 * OneBorn(s12, s13, s14, s23, s24, s34, m12, m22, m32) +
                       TwoBorn(s12, s13, s14, s23, s24, s34, m12, m22, m32);
         if (polarized) {
-            const VectorLor n{-InitialStatePolarization()};
+            const VectorLor n{-ISPolarization()};
             const auto s2n{s(p2, n)};
             const auto s3n{s(p3, n)};
             const auto s4n{s(p4, n)};
@@ -2869,7 +2869,7 @@ MUSTARD_OPTIMIZE_FAST auto MSqM2ENNEE::TwoBornPol(double s12, double s13, double
 MUSTARD_OPTIMIZE_FAST auto MSqM2ENNEE::MSqMcMuleLegacy(const InitialStateMomenta& pI, const FinalStateMomenta& pF) const -> double {
     const auto& q1{pI};
     const auto& [q2, q3, q4, q6, q5]{pF}; // should 5 <-> 6 for this version
-    const VectorLor pol1{InitialStatePolarization()};
+    const VectorLor pol1{ISPolarization()};
 
     // Adapt from McMule v0.5.1, mudecrare/mudecrare_pm2ennee.f95, FUNCTION PM2ENNEE
     //

--- a/src/Mustard/Physics/QFT/MSqM2ENNEE.c++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNEE.c++
@@ -62,7 +62,7 @@ auto MSqM2ENNEE::MSqMcMule0Av(const InitialStateMomenta& pI, const FinalStateMom
     const auto m12{p1.m2()};
     const auto m32{p3.m2()};
 
-    const auto polarized{ISPolarization() != Vector3D{}};
+    const auto polarized{Polarization() != Vector3D{}};
     const auto sqrtM12{polarized ? std::sqrt(m12) : 0};
 
     double pm2enneeav{};
@@ -76,7 +76,7 @@ auto MSqM2ENNEE::MSqMcMule0Av(const InitialStateMomenta& pI, const FinalStateMom
         pm2enneeav += 2 * OneBorn(s12, s13, s14, s23, s24, s34, m12, m22, m32) +
                       TwoBorn(s12, s13, s14, s23, s24, s34, m12, m22, m32);
         if (polarized) {
-            const VectorLor n{-ISPolarization()};
+            const VectorLor n{-Polarization()};
             const auto s2n{s(p2, n)};
             const auto s3n{s(p3, n)};
             const auto s4n{s(p4, n)};
@@ -2869,7 +2869,7 @@ MUSTARD_OPTIMIZE_FAST auto MSqM2ENNEE::TwoBornPol(double s12, double s13, double
 MUSTARD_OPTIMIZE_FAST auto MSqM2ENNEE::MSqMcMuleLegacy(const InitialStateMomenta& pI, const FinalStateMomenta& pF) const -> double {
     const auto& q1{pI};
     const auto& [q2, q3, q4, q6, q5]{pF}; // should 5 <-> 6 for this version
-    const VectorLor pol1{ISPolarization()};
+    const VectorLor pol1{Polarization()};
 
     // Adapt from McMule v0.5.1, mudecrare/mudecrare_pm2ennee.f95, FUNCTION PM2ENNEE
     //

--- a/src/Mustard/Physics/QFT/MSqM2ENNEE.h++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNEE.h++
@@ -25,7 +25,7 @@ namespace Mustard::inline Physics::QFT {
 
 /// @class MSqM2ENNEE
 /// @brief Matrix element squared for μ⁻ → e⁻ννe⁺e⁻ and μ⁺ → e⁺ννe⁻e⁺ decays.
-/// Neutrino energies are averaged over.
+/// Neutrino momenta are averaged over.
 ///
 /// Implements polarized matrix element squared for muon decay with internal conversion
 /// (radiative decay where virtual photon converts to e⁺e⁻ pair). Referenceing

--- a/src/Mustard/Physics/QFT/MSqM2ENNEE.h++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNEE.h++
@@ -28,7 +28,7 @@ namespace Mustard::inline Physics::QFT {
 /// Neutrino momenta are averaged over.
 ///
 /// Implements polarized matrix element squared for muon decay with internal conversion
-/// (radiative decay where virtual photon converts to e⁺e⁻ pair). Referenceing
+/// (radiative decay where virtual photon converts to e⁺e⁻ pair). Referencing
 /// McMule's analytical formula.
 class MSqM2ENNEE : public PolarizedMatrixElement<1, 5> {
 public:

--- a/src/Mustard/Physics/QFT/MSqM2ENNG.c++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNG.c++
@@ -1,0 +1,117 @@
+// -*- C++ -*-
+//
+// Copyright (C) 2020-2025  Mustard developers
+//
+// This file is part of Mustard, an offline software framework for HEP experiments.
+//
+// Mustard is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// Mustard is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Mustard. If not, see <https://www.gnu.org/licenses/>.
+
+#include "Mustard/Math/Vector.h++"
+#include "Mustard/Physics/QFT/MSqM2ENNG.h++"
+#include "Mustard/Utility/MathConstant.h++"
+#include "Mustard/Utility/PhysicalConstant.h++"
+
+#include "muc/math"
+
+namespace Mustard::inline Physics::QFT {
+
+using namespace PhysicalConstant;
+using namespace MathConstant;
+
+auto MSqM2ENNG::operator()(const InitialStateMomenta& pI, const FinalStateMomenta& pF) const -> double {
+    const auto& q1{pI};
+    const auto& [q2, _1, _2, q5]{pF};
+
+    // Adapt from McMule v0.7, mudec/mudec_mat_el.f95
+    //
+    // Copyright (C) 2020-2026  Yannick Ulrich and others (The McMule development team)
+    //
+
+    const auto& p1{q1};
+    const auto p2{q1 - q2};
+    const auto& p4{q5};
+
+    const auto mm{q1.m()};
+    const auto me2{q2.m2()};
+
+    const auto p1p2{p1 * p2};
+    const auto p1p4{p1 * p4};
+    const auto p2p4{p2 * p4};
+
+    const VectorLor pol1{Polarization()};
+    const auto np2{pol1 * p2};
+    const auto np4{pol1 * p4};
+
+    return PM2ENNGav(mm, me2, p1p2, p1p4, p2p4, np2, np4);
+}
+
+MUSTARD_OPTIMIZE_FAST auto MSqM2ENNG::PM2ENNGav(double mm, double me2, double p1p2, double p1p4,
+                                                double p2p4, double np2, double np4) -> double {
+    using muc::pow;
+
+    // Adapt from McMule v0.7, mudec/mudec_mat_el.f95
+    //
+    // Copyright (C) 2020-2026  Yannick Ulrich and others (The McMule development team)
+    //
+
+    const auto mm2{pow(mm, 2)};
+    return ((-32 * 4 * pi * fine_structure_const *
+             pow(reduced_Fermi_constant, 2) *
+             (pow(me2, 2) * p1p4 *
+                  (mm2 * p1p4 - 3 * mm * np4 * p2p4 +
+                   3 * p1p4 * (-p1p2 + p2p4)) +
+              me2 * (3 * pow(mm, 3) * np4 * (2 * p1p4 - p2p4) * p2p4 +
+                     pow(mm2, 2) * (-2 * pow(p1p4, 2) + pow(p2p4, 2)) +
+                     p1p4 * (-4 * pow(p1p4, 3) + 8 * pow(p1p4, 2) * p2p4 +
+                             2 * p1p2 * (7 * p1p4 - 3 * p2p4) * p2p4 -
+                             11 * p1p4 * pow(p2p4, 2) + 3 * pow(p2p4, 3) +
+                             pow(p1p2, 2) * (-10 * p1p4 + 6 * p2p4)) +
+                     mm * np4 *
+                         (4 * pow(p1p4, 3) - 8 * pow(p1p4, 2) * p2p4 +
+                          3 * (p1p2 - p2p4) * pow(p2p4, 2) +
+                          p1p4 * p2p4 * (-7 * p1p2 + 11 * p2p4)) +
+                     mm2 * (-8 * pow(p1p4, 2) * p2p4 + 3 * pow(p2p4, 3) +
+                            p1p2 * (10 * pow(p1p4, 2) - 2 * p1p4 * p2p4 -
+                                    3 * pow(p2p4, 2)))) +
+              (p1p4 - p2p4) *
+                  (-3 * pow(mm, 5) * np4 * p2p4 + pow(mm2, 3) * (p1p4 + p2p4) +
+                   pow(mm, 3) * np4 *
+                       (-4 * pow(p1p4, 2) + 4 * p1p4 * p2p4 +
+                        7 * (p1p2 - p2p4) * p2p4) -
+                   4 * p1p4 * (p1p2 - p2p4) *
+                       (2 * pow(p1p2, 2) + 2 * pow(p1p4, 2) - 2 * p1p2 * p2p4 -
+                        2 * p1p4 * p2p4 + pow(p2p4, 2)) +
+                   mm2 * (4 * pow(p1p4, 3) - 4 * pow(p1p4, 2) * p2p4 +
+                          5 * p1p4 * pow(p2p4, 2) + 4 * pow(p2p4, 3) +
+                          2 * pow(p1p2, 2) * (7 * p1p4 + 2 * p2p4) -
+                          2 * p1p2 * p2p4 * (9 * p1p4 + 4 * p2p4)) +
+                   pow(mm2, 2) * (5 * p2p4 * (p1p4 + p2p4) -
+                                  p1p2 * (7 * p1p4 + 5 * p2p4)) -
+                   4 * mm * np4 *
+                       (pow(p1p2, 2) * p2p4 +
+                        p2p4 * (2 * pow(p1p4, 2) - 2 * p1p4 * p2p4 +
+                                pow(p2p4, 2)) -
+                        2 * p1p2 *
+                            (pow(p1p4, 2) - p1p4 * p2p4 + pow(p2p4, 2)))) +
+              mm * np2 *
+                  (3 * pow(me2, 2) * pow(p1p4, 2) +
+                   (p1p4 - p2p4) * (3 * mm2 - 4 * p1p2 + 4 * p2p4) *
+                       (p1p4 * (-2 * p1p2 + p2p4) + mm2 * (p1p4 + p2p4)) +
+                   me2 * (mm2 * (-6 * pow(p1p4, 2) + 3 * pow(p2p4, 2)) +
+                          p1p4 * (10 * p1p2 * p1p4 - 6 * p1p2 * p2p4 -
+                                  7 * p1p4 * p2p4 + 3 * pow(p2p4, 2)))))) /
+            (3. * pow(p1p4, 2) * pow(p1p4 - p2p4, 2))) /
+           2;
+}
+
+} // namespace Mustard::inline Physics::QFT

--- a/src/Mustard/Physics/QFT/MSqM2ENNG.h++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNG.h++
@@ -28,7 +28,7 @@ namespace Mustard::inline Physics::QFT {
 /// Neutrino momenta are averaged over.
 ///
 /// Implements polarized matrix element calculation for radiative muon decay
-/// referenceing McMule's analytical formula.
+/// referencing McMule's analytical formula.
 class MSqM2ENNG : public PolarizedMatrixElement<1, 4> {
 public:
     // Inherit constructor

--- a/src/Mustard/Physics/QFT/MSqM2ENNG.h++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNG.h++
@@ -1,0 +1,50 @@
+// -*- C++ -*-
+//
+// Copyright (C) 2020-2025  Mustard developers
+//
+// This file is part of Mustard, an offline software framework for HEP experiments.
+//
+// Mustard is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// Mustard is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Mustard. If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "Mustard/Physics/QFT/PolarizedMatrixElement.h++"
+#include "Mustard/Utility/FunctionAttribute.h++"
+
+namespace Mustard::inline Physics::QFT {
+
+/// @class MSqM2ENNG
+/// @brief Matrix element squared for μ⁻ → e⁻ννγ and μ⁺ → e⁺ννγ decays.
+/// Neutrino momenta are averaged over.
+///
+/// Implements polarized matrix element calculation for radiative muon decay
+/// referenceing McMule's analytical formula.
+class MSqM2ENNG : public PolarizedMatrixElement<1, 4> {
+public:
+    // Inherit constructor
+    using PolarizedMatrixElement::PolarizedMatrixElement;
+
+    /// @brief Calculate squared matrix element for radiative muon decay
+    /// @param pI Muon 4-momentum
+    /// @param pF Final state 4-momenta: [e, ν, ν, γ]
+    /// @return |M|² value in CLHEP unit system
+    ///
+    /// @note Implementation based on McMule's analytical expressions
+    virtual auto operator()(const InitialStateMomenta& pI, const FinalStateMomenta& pF) const -> double override;
+
+private:
+    MUSTARD_OPTIMIZE_FAST static auto PM2ENNGav(double mm, double me2, double p1p2, double p1p4,
+                                                double p2p4, double np2, double np4) -> double;
+};
+
+} // namespace Mustard::inline Physics::QFT

--- a/src/Mustard/Physics/QFT/MSqM2ENNGG.c++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNGG.c++
@@ -61,8 +61,8 @@ auto MSqM2ENNGG::operator()(const InitialStateMomenta& pI, const FinalStateMomen
 
     auto pm2ennggav{Unpolarized(mm2, me2, s12, s15, s16, s25, s26, s56,
                                 den1, den2, den3, den4, den5, den6)};
-    if (ISPolarization() != Vector3D{}) {
-        const VectorLor pol1{ISPolarization()};
+    if (Polarization() != Vector3D{}) {
+        const VectorLor pol1{Polarization()};
         pm2ennggav += s(pol1, p2) * PolarizedS2n(mm2, me2, s12, s15, s16, s25, s26, s56,
                                                  den1, den2, den3, den4, den5, den6);
         pm2ennggav += s(pol1, p5) * PolarizedS5n(mm2, me2, s12, s15, s16, s25, s26, s56,

--- a/src/Mustard/Physics/QFT/MSqM2ENNGG.c++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNGG.c++
@@ -61,8 +61,8 @@ auto MSqM2ENNGG::operator()(const InitialStateMomenta& pI, const FinalStateMomen
 
     auto pm2ennggav{Unpolarized(mm2, me2, s12, s15, s16, s25, s26, s56,
                                 den1, den2, den3, den4, den5, den6)};
-    if (InitialStatePolarization() != Vector3D{}) {
-        const VectorLor pol1{InitialStatePolarization()};
+    if (ISPolarization() != Vector3D{}) {
+        const VectorLor pol1{ISPolarization()};
         pm2ennggav += s(pol1, p2) * PolarizedS2n(mm2, me2, s12, s15, s16, s25, s26, s56,
                                                  den1, den2, den3, den4, den5, den6);
         pm2ennggav += s(pol1, p5) * PolarizedS5n(mm2, me2, s12, s15, s16, s25, s26, s56,

--- a/src/Mustard/Physics/QFT/MSqM2ENNGG.h++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNGG.h++
@@ -25,7 +25,7 @@ namespace Mustard::inline Physics::QFT {
 
 /// @class MSqM2ENNGG
 /// @brief Matrix element squared for μ⁻ → e⁻ννγγ and μ⁺ → e⁺ννγγ decays.
-/// Neutrino energies are averaged over.
+/// Neutrino momenta are averaged over.
 ///
 /// Implements polarized matrix element calculation for double radiative muon decay
 /// referenceing McMule's analytical formula.

--- a/src/Mustard/Physics/QFT/MSqM2ENNGG.h++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNGG.h++
@@ -31,6 +31,7 @@ namespace Mustard::inline Physics::QFT {
 /// referenceing McMule's analytical formula.
 class MSqM2ENNGG : public PolarizedMatrixElement<1, 5> {
 public:
+    // Inherit constructor
     using PolarizedMatrixElement::PolarizedMatrixElement;
 
     /// @brief Calculate squared matrix element for double radiative muon decay

--- a/src/Mustard/Physics/QFT/MSqM2ENNGG.h++
+++ b/src/Mustard/Physics/QFT/MSqM2ENNGG.h++
@@ -28,7 +28,7 @@ namespace Mustard::inline Physics::QFT {
 /// Neutrino momenta are averaged over.
 ///
 /// Implements polarized matrix element calculation for double radiative muon decay
-/// referenceing McMule's analytical formula.
+/// referencing McMule's analytical formula.
 class MSqM2ENNGG : public PolarizedMatrixElement<1, 5> {
 public:
     // Inherit constructor

--- a/src/Mustard/Physics/QFT/MatrixElement.h++
+++ b/src/Mustard/Physics/QFT/MatrixElement.h++
@@ -38,6 +38,8 @@ class MatrixElement {
 public:
     /// @brief Initial state momentum(a) type
     using InitialStateMomenta = std::conditional_t<M == 1, VectorLor, std::array<VectorLor, M>>;
+    /// @brief Initial state polarization vector(s) type (for PolarizedMatrixElement)
+    using InitialStatePolarization = std::conditional_t<M == 1, Vector3D, std::array<Vector3D, M>>;
     /// @brief Final state momenta type
     using FinalStateMomenta = std::array<VectorLor, N>;
 

--- a/src/Mustard/Physics/QFT/PolarizedMatrixElement.h++
+++ b/src/Mustard/Physics/QFT/PolarizedMatrixElement.h++
@@ -51,26 +51,26 @@ public:
 
     /// @brief Get initial-state polarization vector(s)
     /// @return Initial-state polarization vector(s)
-    auto ISPolarization() const -> const auto& { return fISPolarization; }
+    auto Polarization() const -> const auto& { return fPolarization; }
     /// @brief Get polarization vector for single initial-state particle
     /// @param i Particle index (0 ≤ i < M)
     /// @return Polarization vector
     /// @note This overload is only enabled for polarized scattering (M > 1)
-    auto ISPolarization(int i) const -> auto
-        requires(M > 1) { return fISPolarization.at(i); }
+    auto Polarization(int i) const -> auto
+        requires(M > 1) { return fPolarization.at(i); }
 
     /// @brief Set initial-state polarization vector(s)
     /// @param pol Initial-state polarization vector(s) (all |p| ≤ 1)
-    auto ISPolarization(const InitialStatePolarization& pol) -> void;
+    auto Polarization(const InitialStatePolarization& pol) -> void;
     /// @brief Set polarization for single initial-state particle
     /// @param i Particle index (0 ≤ i < M)
     /// @param pol Polarization vector (|p| ≤ 1)
     /// @note This overload is only enabled for polarized scattering (M > 1)
-    auto ISPolarization(int i, Vector3D pol) -> void
+    auto Polarization(int i, Vector3D pol) -> void
         requires(M > 1);
 
 private:
-    InitialStatePolarization fISPolarization; ///< Polarization storage
+    InitialStatePolarization fPolarization; ///< Polarization storage
 };
 
 } // namespace Mustard::inline Physics::QFT

--- a/src/Mustard/Physics/QFT/PolarizedMatrixElement.h++
+++ b/src/Mustard/Physics/QFT/PolarizedMatrixElement.h++
@@ -32,60 +32,45 @@ namespace Mustard::inline Physics::QFT {
 /// @brief Base for polarized squared matrix element functor
 ///
 /// Extends `MatrixElement` with polarization handling for initial-state particle(s).
-/// Provides storage and access methods for initial particle polarization vector(s).
+/// Provides storage and access methods for initial-state particle polarization vector(s).
 ///
 /// @tparam M Number of initial-state particles (M ≥ 1)
 /// @tparam N Number of final-state particles (N ≥ 1)
 template<int M, int N>
 class PolarizedMatrixElement : public MatrixElement<M, N> {
 public:
+    /// @brief Initial state polarization vector(s) type
+    using typename MatrixElement<M, N>::InitialStatePolarization;
+
+public:
     /// @brief Default constructor (all polarizations zero)
     PolarizedMatrixElement() = default;
-    /// @brief Construct with initial polarization array
-    /// @param pol Array of polarization vectors for each initial particle (all |p| ≤ 1)
-    PolarizedMatrixElement(const std::array<Vector3D, M>& pol);
+    /// @brief Construct with initial-state polarization vectors
+    /// @param pol Array of polarization vectors for each initial-state particle (all |p| ≤ 1)
+    PolarizedMatrixElement(const InitialStatePolarization& pol);
 
-    /// @brief Get polarization vector for single initial particle
+    /// @brief Get initial-state polarization vector(s)
+    /// @return Initial-state polarization vector(s)
+    auto ISPolarization() const -> const auto& { return fISPolarization; }
+    /// @brief Get polarization vector for single initial-state particle
     /// @param i Particle index (0 ≤ i < M)
-    auto InitialStatePolarization(int i) const -> auto { return fInitialStatePolarization.at(i); }
-    /// @brief Get all polarization vectors
-    auto InitialStatePolarization() const -> const auto& { return fInitialStatePolarization; }
+    /// @return Polarization vector
+    /// @note This overload is only enabled for polarized scattering (M > 1)
+    auto ISPolarization(int i) const -> auto
+        requires(M > 1) { return fISPolarization.at(i); }
 
-    /// @brief Set polarization for single initial particle
+    /// @brief Set initial-state polarization vector(s)
+    /// @param pol Initial-state polarization vector(s) (all |p| ≤ 1)
+    auto ISPolarization(const InitialStatePolarization& pol) -> void;
+    /// @brief Set polarization for single initial-state particle
     /// @param i Particle index (0 ≤ i < M)
     /// @param pol Polarization vector (|p| ≤ 1)
-    auto InitialStatePolarization(int i, Vector3D pol) -> void;
-    /// @brief Set all polarization vectors
-    /// @param pol Array of polarization vectors for each initial particle (all |p| ≤ 1)
-    auto InitialStatePolarization(const std::array<Vector3D, M>& pol) -> void;
+    /// @note This overload is only enabled for polarized scattering (M > 1)
+    auto ISPolarization(int i, Vector3D pol) -> void
+        requires(M > 1);
 
 private:
-    std::array<Vector3D, M> fInitialStatePolarization; ///< Polarization storage
-};
-
-/// @class PolarizedMatrixElement<1, N>
-/// @brief Specialization for single initial-state particle
-///
-/// Simplified interface for decay processes (1→N) with single polarization vector.
-///
-/// @tparam N Number of final-state particles (N ≥ 1)
-template<int N>
-class PolarizedMatrixElement<1, N> : public MatrixElement<1, N> {
-public:
-    /// @brief Default constructor (zero polarization)
-    PolarizedMatrixElement() = default;
-    /// @brief Construct with polarization vector
-    /// @param pol Polarization vector (|p| ≤ 1)
-    PolarizedMatrixElement(Vector3D pol);
-
-    /// @brief Get polarization vector
-    auto InitialStatePolarization() const -> auto { return fInitialStatePolarization; }
-    /// @brief Set polarization vector
-    /// @param pol Polarization vector (|p| ≤ 1)
-    auto InitialStatePolarization(Vector3D pol) -> void;
-
-private:
-    Vector3D fInitialStatePolarization;
+    InitialStatePolarization fISPolarization; ///< Polarization storage
 };
 
 } // namespace Mustard::inline Physics::QFT

--- a/src/Mustard/Physics/QFT/PolarizedMatrixElement.h++
+++ b/src/Mustard/Physics/QFT/PolarizedMatrixElement.h++
@@ -45,8 +45,8 @@ public:
 public:
     /// @brief Default constructor (all polarizations zero)
     PolarizedMatrixElement() = default;
-    /// @brief Construct with initial-state polarization vectors
-    /// @param pol Array of polarization vectors for each initial-state particle (all |p| ≤ 1)
+    /// @brief Construct with initial-state polarization vector(s)
+    /// @param pol Initial-state polarization vector(s) for each initial-state particle (all |p| ≤ 1)
     PolarizedMatrixElement(const InitialStatePolarization& pol);
 
     /// @brief Get initial-state polarization vector(s)

--- a/src/Mustard/Physics/QFT/PolarizedMatrixElement.inl
+++ b/src/Mustard/Physics/QFT/PolarizedMatrixElement.inl
@@ -21,32 +21,32 @@ namespace Mustard::inline Physics::QFT {
 template<int M, int N>
 PolarizedMatrixElement<M, N>::PolarizedMatrixElement(const InitialStatePolarization& pol) :
     PolarizedMatrixElement{} {
-    ISPolarization(pol);
+    Polarization(pol);
 }
 
 template<int M, int N>
-auto PolarizedMatrixElement<M, N>::ISPolarization(const InitialStatePolarization& pol) -> void {
+auto PolarizedMatrixElement<M, N>::Polarization(const InitialStatePolarization& pol) -> void {
     if constexpr (M == 1) {
         const auto polNorm{pol.mag()};
         if (polNorm > 1) [[unlikely]] {
             PrintWarning(fmt::format("Got polarization (pol) with |pol| = {} (expects |pol| <= 1)", polNorm));
         }
-        fISPolarization = pol;
+        fPolarization = pol;
     } else {
         for (int i{}; i < M; ++i) {
-            ISPolarization(i, pol[i]);
+            Polarization(i, pol[i]);
         }
     }
 }
 
 template<int M, int N>
-auto PolarizedMatrixElement<M, N>::ISPolarization(int i, Vector3D pol) -> void
+auto PolarizedMatrixElement<M, N>::Polarization(int i, Vector3D pol) -> void
     requires(M > 1) {
     const auto polNorm{pol.mag()};
     if (polNorm > 1) [[unlikely]] {
         PrintWarning(fmt::format("Got polarization {} (pol) with |pol| = {} (expects |pol| <= 1)", i, polNorm));
     }
-    fISPolarization.at(i) = pol;
+    fPolarization.at(i) = pol;
 }
 
 } // namespace Mustard::inline Physics::QFT

--- a/src/Mustard/Physics/QFT/PolarizedMatrixElement.inl
+++ b/src/Mustard/Physics/QFT/PolarizedMatrixElement.inl
@@ -19,40 +19,34 @@
 namespace Mustard::inline Physics::QFT {
 
 template<int M, int N>
-PolarizedMatrixElement<M, N>::PolarizedMatrixElement(const std::array<Vector3D, M>& pol) :
+PolarizedMatrixElement<M, N>::PolarizedMatrixElement(const InitialStatePolarization& pol) :
     PolarizedMatrixElement{} {
-    InitialStatePolarization(pol);
+    ISPolarization(pol);
 }
 
 template<int M, int N>
-auto PolarizedMatrixElement<M, N>::InitialStatePolarization(int i, Vector3D pol) -> void {
+auto PolarizedMatrixElement<M, N>::ISPolarization(const InitialStatePolarization& pol) -> void {
+    if constexpr (M == 1) {
+        const auto polNorm{pol.mag()};
+        if (polNorm > 1) [[unlikely]] {
+            PrintWarning(fmt::format("Got polarization (pol) with |pol| = {} (expects |pol| <= 1)", polNorm));
+        }
+        fISPolarization = pol;
+    } else {
+        for (int i{}; i < M; ++i) {
+            ISPolarization(i, pol[i]);
+        }
+    }
+}
+
+template<int M, int N>
+auto PolarizedMatrixElement<M, N>::ISPolarization(int i, Vector3D pol) -> void
+    requires(M > 1) {
     const auto polNorm{pol.mag()};
     if (polNorm > 1) [[unlikely]] {
         PrintWarning(fmt::format("Got polarization {} (pol) with |pol| = {} (expects |pol| <= 1)", i, polNorm));
     }
-    fInitialStatePolarization.at(i) = pol;
-}
-
-template<int M, int N>
-auto PolarizedMatrixElement<M, N>::InitialStatePolarization(const std::array<Vector3D, M>& pol) -> void {
-    for (int i{}; i < M; ++i) {
-        InitialStatePolarization(i, pol[i]);
-    }
-}
-
-template<int N>
-PolarizedMatrixElement<1, N>::PolarizedMatrixElement(Vector3D pol) :
-    PolarizedMatrixElement{} {
-    InitialStatePolarization(pol);
-}
-
-template<int N>
-auto PolarizedMatrixElement<1, N>::InitialStatePolarization(Vector3D pol) -> void {
-    const auto polNorm{pol.mag()};
-    if (polNorm > 1) [[unlikely]] {
-        PrintWarning(fmt::format("Got polarization (pol) with |pol| = {} (expects |pol| <= 1)", polNorm));
-    }
-    fInitialStatePolarization = pol;
+    fISPolarization.at(i) = pol;
 }
 
 } // namespace Mustard::inline Physics::QFT


### PR DESCRIPTION
## Summary
This pull request introduces several improvements and refactors to the event generator classes in the Mustard physics framework. The main changes include standardizing the interface for setting parent momentum and cutoff parameters, updating generator classes to use faster random sampling, and improving naming consistency and clarity. Additionally, a new generator class for μ→eννγ decays is added.

**Generator interface and cutoff refactor:**

* Replaced the `ParentMomentum` method with a standardized `Momentum` method in generator classes (`M2ENNEGenerator`, `M2ENNEEGenerator`, `M2ENNGGGenerator`, and new `M2ENNGGenerator`), improving naming consistency and clarity. [[1]](diffhunk://#diff-bb4c9b0a7f8fa75a7f6fe8c74545daed183fae05d809328b502ef58c0e21f8a3L58-R58) [[2]](diffhunk://#diff-a009c06af304cbc0a968c3e4a33dd0715d2e61a92dcf8833526b6205055861b4L51-R51) [[3]](diffhunk://#diff-0147202e2577fe313c4d25d92336d2a5b5b724c6811ef337e30037fdc6497a52L58-R60) [[4]](diffhunk://#diff-5ae38039c9de0c5ec142e39cae35211a7a0abbf4a78ff094bbbfe68b98de5f67L54-R56) [[5]](diffhunk://#diff-2878a60092d853b76528a176656782a3d5e34e95c56917efe45a50cc4b62a547L56-R70) [[6]](diffhunk://#diff-4f4296d28c1e9c3c02509737c95f19b340ff042c5a7b6f00b526b2050ac6d281R1-R65) [[7]](diffhunk://#diff-70940427783cb47754e35a9621c8bb73986328d7c83cec6bf35e79a36d597b4bR1-R70)
* Refactored cutoff handling for final-state photons in `M2ENNGGGenerator` and new `M2ENNGGenerator` classes: replaced the single `IRCut` method with separate `SoftCutoff` and `CollinearCutoff` methods, allowing explicit control over low-energy and collinear cutoffs. [[1]](diffhunk://#diff-2878a60092d853b76528a176656782a3d5e34e95c56917efe45a50cc4b62a547L35-R44) [[2]](diffhunk://#diff-ce828d5b8fb30063ab9169b989bb5b713b84ada0cc0377f24abab724bbb84f49L40-R46) [[3]](diffhunk://#diff-ce828d5b8fb30063ab9169b989bb5b713b84ada0cc0377f24abab724bbb84f49L54-R62) [[4]](diffhunk://#diff-4f4296d28c1e9c3c02509737c95f19b340ff042c5a7b6f00b526b2050ac6d281R1-R65) [[5]](diffhunk://#diff-70940427783cb47754e35a9621c8bb73986328d7c83cec6bf35e79a36d597b4bR1-R70)

**New generator implementation:**

* Added new `M2ENNGGenerator` class for μ→eννγ decays, including construction, momentum/cutoff setters, and parent particle selection. [[1]](diffhunk://#diff-4f4296d28c1e9c3c02509737c95f19b340ff042c5a7b6f00b526b2050ac6d281R1-R65) [[2]](diffhunk://#diff-70940427783cb47754e35a9621c8bb73986328d7c83cec6bf35e79a36d597b4bR1-R70)

**Random sampling improvements:**

* Updated `AdaptiveMTMGenerator` and `ClassicalMetropolisGenerator` to use `Random::GaussianFast<double>` instead of `Random::Gaussian<double>`, improving performance of random sampling. [[1]](diffhunk://#diff-9084a29332f398b832f0d898e27ff0d88cf66eda61a90f209a18d47697cce158L128-R128) [[2]](diffhunk://#diff-1214b56815ab2b0cdcb700203799eacf8fb92cd2e130bc679d759253210e0bf2L127-R127)

**Acceptance and safety function renaming:**

* Renamed acceptance and safety methods for clarity: `IRSafe` → `InfraredSafe`, `ValidAcceptance` → `Acceptance`, and `ValidMSqAcceptanceDetJ` → `MSqAcceptanceDetJ` in generator implementations. [[1]](diffhunk://#diff-ccc587454e523046ce11745d8d5e7247a45f3c20d3c56de6b171f0b846c2f626L124-R129) [[2]](diffhunk://#diff-ccc587454e523046ce11745d8d5e7247a45f3c20d3c56de6b171f0b846c2f626L151-R155) [[3]](diffhunk://#diff-ac7f2cad7b1fb716eb5c0626c9f0717894efbb296b9b62185234f58565e47277L109-R111)

**Documentation and naming improvements:**

* Improved documentation and comments in generator headers to clarify parameter meaning and avoid hiding base class operator overloads. [[1]](diffhunk://#diff-a872fcf30432410de44435ef25f0967160af8f91671e7f55affd8b08450b54e8L155-R155) [[2]](diffhunk://#diff-a57731ef7b0a75c10f6d739393d9f3927fefe3f72cab658b5912ecfe51194213L91-R91) [[3]](diffhunk://#diff-1dcde99a4373197a4dee3d32b5f71614bbf0b7c6e5ec1d45ccaad68291a87aedL100-R100)

These changes collectively improve the usability, clarity, and performance of the event generator classes and their interfaces.

## Type of change
- New feature (non-breaking change which adds functionality)
